### PR TITLE
토큰 재발급 로직 변경 및 멤버 싱글룸리스트 로직 수정

### DIFF
--- a/src/main/java/challenge/nDaysChallenge/controller/dajim/EmotionController.java
+++ b/src/main/java/challenge/nDaysChallenge/controller/dajim/EmotionController.java
@@ -18,7 +18,7 @@ public class EmotionController { //감정 스티커 등록
 
     private final EmotionService emotionService;
 
-    //감정 스티커 등록 (프론트 unselected 시)
+    //감정 스티커 new 등록 (프론트 unselected된 상태에서)
     @PostMapping("/feed/emotion")
     public ResponseEntity<?> uploadEmotion(@RequestBody EmotionRequestDto emotionRequestDto,
                                            @AuthenticationPrincipal MemberAdapter memberAdapter){
@@ -27,7 +27,7 @@ public class EmotionController { //감정 스티커 등록
         return ResponseEntity.ok().body(emotionResponseDto);
     }
 
-    //감정 스티커 변경/null (프론트 selected 시)
+    //감정 스티커 변경 or null 등록 (프론트 selected된 상태에서 다른 스티커 select 시 or 두번 똑같은 스티커 클릭 시)
     @PutMapping("/feed/emotion")
     public ResponseEntity<?> updateEmotion(@RequestBody EmotionRequestDto emotionRequestDto,
                                          @AuthenticationPrincipal MemberAdapter memberAdapter){

--- a/src/main/java/challenge/nDaysChallenge/controller/dajim/EmotionController.java
+++ b/src/main/java/challenge/nDaysChallenge/controller/dajim/EmotionController.java
@@ -28,7 +28,7 @@ public class EmotionController { //감정 스티커 등록
     }
 
     //감정 스티커 변경 or null 등록 (프론트 selected된 상태에서 다른 스티커 select 시 or 두번 똑같은 스티커 클릭 시)
-    @PutMapping("/feed/emotion")
+    @PatchMapping("/feed/emotion")
     public ResponseEntity<?> updateEmotion(@RequestBody EmotionRequestDto emotionRequestDto,
                                          @AuthenticationPrincipal MemberAdapter memberAdapter){
 

--- a/src/main/java/challenge/nDaysChallenge/domain/Member.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/Member.java
@@ -70,4 +70,8 @@ public class Member {
         this.confirmedFriendsList.add(member);
     }
 
+    public void addSingleRooms (SingleRoom singleRoom){
+        this.singleRooms.add(singleRoom);
+    }
+
 }

--- a/src/main/java/challenge/nDaysChallenge/domain/room/SingleRoom.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/room/SingleRoom.java
@@ -34,7 +34,7 @@ public class SingleRoom extends Room {
     //==연관관계 메서드==//  SingleRoom의 room에 roomNumber 넣으면서 singleRooms에도 roomNumber 세팅
     public void joinRoom(Room room) {
         this.room = room;
-        member.getSingleRooms().add(this);
+        this.member.addSingleRooms(this);
     }
 
     //==생성 메서드==//

--- a/src/main/java/challenge/nDaysChallenge/jwt/TokenProvider.java
+++ b/src/main/java/challenge/nDaysChallenge/jwt/TokenProvider.java
@@ -76,6 +76,31 @@ public class TokenProvider { //유저 정보로 JWT 토큰 생성 & 토큰 통�
 
     }
 
+    public TokenDto reissueToken(Authentication authentication, RefreshToken refreshToken) {
+        //권한들 가져오기 (문자열 변환)
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        Long now = (new Date()).getTime();
+
+        //access token 생성
+        Date accessTokenExpireTime = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName()) //페이로드 "sub":"이름"
+                .claim(AUTHORITY, authorities) //페이로드 "auth":"ROLE_USER"
+                .setExpiration(accessTokenExpireTime) //페이로드 "exp":만료시간
+                .signWith(key, SignatureAlgorithm.HS256) //헤더 "alg":"HS512"
+                .compact();
+
+        return TokenDto.builder()
+                .type(BEARER_TYPE)
+                .accessToken(accessToken)
+                .accessTokenExpireTime(accessTokenExpireTime.getTime())
+                .refreshToken(refreshToken.toString())
+                .build();
+    }
+
     //토큰 내 데이터(클레임) 가져오기
     public Authentication getAuthentication(String accessToken){
         //토큰 복호화(읽기)

--- a/src/main/java/challenge/nDaysChallenge/service/AuthService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/AuthService.java
@@ -102,7 +102,7 @@ public class AuthService { //회원가입 & 로그인 & 토큰 재발급
         SecurityContextHolder.clearContext(); // 시큐리티 컨텍스트에서 인증 정보 삭제
     }
 
-    //토큰 재발급
+    //액세스토큰 재발급
     public TokenDto reissue(JwtRequestDto tokenRequestDto) {
 
         //refresh 토큰 유효성(만료 여부) 검증
@@ -123,11 +123,11 @@ public class AuthService { //회원가입 & 로그인 & 토큰 재발급
         }
 
         //토큰 생성
-        TokenDto tokenDto = tokenProvider.generateToken(authentication);
+        TokenDto tokenDto = tokenProvider.reissueToken(authentication, refreshToken);
 
         //저장소에 새 리프레시 토큰 저장
-        RefreshToken newRefreshToken = refreshToken.updateValue(tokenDto.getRefreshToken());
-        refreshTokenRepository.save(newRefreshToken);
+//        RefreshToken newRefreshToken = refreshToken.updateValue(tokenDto.getRefreshToken());
+//        refreshTokenRepository.save(newRefreshToken);
 
         //JWT 토큰 재발급
         return tokenDto;

--- a/src/main/java/challenge/nDaysChallenge/service/RoomService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/RoomService.java
@@ -61,7 +61,7 @@ public class RoomService {
         singleRoomRepository.save(newRoom);
 
         //멤버에 챌린지 저장
-//        newRoom.addRoom(newRoom, member);
+        member.addSingleRooms(newRoom);
 
         return newRoom;
     }

--- a/src/main/resources/application-mysql.yml
+++ b/src/main/resources/application-mysql.yml
@@ -3,7 +3,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/challenge?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
-    password: '12345678'
+    password: '1234'
 
     hikari:
       initialization-fail-timeout: 0 #커넥션 초기화 실패 시 유효성 검사 시도

--- a/src/test/java/challenge/nDaysChallenge/dajim/DajimFeedRepositoryTest.java
+++ b/src/test/java/challenge/nDaysChallenge/dajim/DajimFeedRepositoryTest.java
@@ -177,11 +177,11 @@ public class DajimFeedRepositoryTest {
         }
 
         //멤버2
-//        assertThat(singleRooms.size()).isEqualTo(1); //싱글룸 0개
-//        assertThat(roomMemberList.size()).isEqualTo(1); //그룹룸 1개
-//        assertThat(dajims.size()).isEqualTo(4); //해당 그룹룸에 다짐 3개
-//        assertThat(dajim3.getEmotions().get(0).getStickers().toString()).isEqualTo("TOUCHED");
-//        assertThat(stickersList.get(0)).isEqualTo("TOUCHED");
+        assertThat(singleRooms.size()).isEqualTo(0); //싱글룸 0개
+        assertThat(roomMemberList.size()).isEqualTo(1); //그룹룸 1개
+        assertThat(dajims.size()).isEqualTo(3); //해당 그룹룸에 다짐 3개
+        assertThat(dajim3.getEmotions().get(0).getStickers().toString()).isEqualTo("TOUCHED");
+        assertThat(stickersList.get(0)).isEqualTo("TOUCHED");
     }
 
     @DisplayName("이모션 등록")

--- a/src/test/java/challenge/nDaysChallenge/dajim/DajimRepositoryTest.java
+++ b/src/test/java/challenge/nDaysChallenge/dajim/DajimRepositoryTest.java
@@ -42,10 +42,17 @@ class DajimRepositoryTest {
                 .build();
         Dajim savedDajim = dajimRepository.save(newDajim);
 
+        checkDajimRoomUser(newDajim, room, member);
+
         //then
         assertThat(newDajim.getMember().getId()).isEqualTo(savedDajim.getMember().getId());
     }
 
+    private static void checkDajimRoomUser(Dajim dajim, Room room, Member member){
+        if (dajim.getRoom()!=room || dajim.getMember()!=member){
+            throw new RuntimeException("다짐에 대한 권한이 없습니다.");
+        }
+    }
 
     @DisplayName("다짐 수정")
     @Test

--- a/src/test/java/challenge/nDaysChallenge/dajim/QueryTest.java
+++ b/src/test/java/challenge/nDaysChallenge/dajim/QueryTest.java
@@ -200,4 +200,13 @@ public class QueryTest { //N+1 테스트
         assertThat(member.getNickname()).isEqualTo("userN");
     }
 
+    @DisplayName("특정 룸넘버에 해당하는 룸 찾기")
+    @Test
+    void findByRoomNumber(){
+        Room room = dajimRepository.findByRoomNumber(1L)
+                .orElseThrow(()->new RuntimeException("룸을 찾을 수 없습니다."));
+
+        assertThat(room.getName()).isEqualTo("SingleRoom");
+    }
+
 }

--- a/src/test/java/challenge/nDaysChallenge/jwt/memberTest.java
+++ b/src/test/java/challenge/nDaysChallenge/jwt/memberTest.java
@@ -73,7 +73,7 @@ public class memberTest {
         assertThat(exists2).isEqualTo(false);
     }
 
-/*    @DisplayName("멤버 닉네임 변경")
+    @DisplayName("멤버 닉네임 변경")
     @Test
     @Transactional
     @Rollback(value = false)
@@ -87,14 +87,9 @@ public class memberTest {
 
         assertThat(updatedMember.getNickname()).isEqualTo("새 닉네임");
         assertThat(updatedMember.getPw()).isEqualTo("123");
-<<<<<<< HEAD
         assertThat(updatedMember.getImage()).isEqualTo(2);
     }
-=======
-        assertThat(updatedMember.getImage()).isEqualTo(1);
-        assertThat(member).isEqualTo(updatedMember);
-    }*/
->>>>>>> cc05eb81cee1fc6543fdb9c075684d89f3438174
+
 
     @DisplayName("멤버 삭제(탈퇴) 시 룸/다짐/이모션 존재 여부 확인")
     @Test

--- a/src/test/java/challenge/nDaysChallenge/security/WithUserDetailsTest.java
+++ b/src/test/java/challenge/nDaysChallenge/security/WithUserDetailsTest.java
@@ -133,7 +133,7 @@ public class WithUserDetailsTest {
         singleRoom.addRoom(singleRoom, currentMember);
 
         //다짐 작성
-        DajimRequestDto dajimRequestDto = new DajimRequestDto(null, "다짐 내용", "PUBLIC");
+        DajimRequestDto dajimRequestDto = new DajimRequestDto(null,"다짐 내용", "PUBLIC");
         Dajim newDajim = Dajim.builder()
                 .room(singleRoom)
                 .member(currentMember)


### PR DESCRIPTION
- 액세스토큰만 재발급되도록 reissue 메소드 로직 변경 (리프레쉬토큰은 7일 후 만료, 재로그인 안내창 뜨도록)
- 멤버 엔티티 내부에 싱글룸리스트에 객체 추가하는 메소드 작성, 서비스에 해당사항 추가