### PR TITLE
오류 코드 수정

### DIFF
--- a/src/main/java/challenge/nDaysChallenge/controller/dajim/DajimController.java
+++ b/src/main/java/challenge/nDaysChallenge/controller/dajim/DajimController.java
@@ -33,7 +33,7 @@ public class DajimController {
         return ResponseEntity.ok().body(dajimResponseDto);
     }
 
-    //전체 다짐 조회
+    //다짐 조회 (챌린지룸 내)
     @GetMapping("/challenge/{challengeId}")
     public ResponseEntity<?> viewDajimOnChallenge(@PathVariable("challengeId") Long roomNumber,
                                                   @AuthenticationPrincipal MemberAdapter memberAdapter){

--- a/src/main/java/challenge/nDaysChallenge/dto/response/EmotionResponseDto.java
+++ b/src/main/java/challenge/nDaysChallenge/dto/response/EmotionResponseDto.java
@@ -12,7 +12,7 @@ import javax.validation.constraints.Null;
 @NoArgsConstructor
 public class EmotionResponseDto {
 
-    private Long dajimNumber; //좋아요 등록한 다짐 넘버
+    private long dajimNumber; //좋아요 등록한 다짐 넘버
 
     private String memberNickname;//좋아요 등록한 멤버 닉네임
 
@@ -26,7 +26,7 @@ public class EmotionResponseDto {
 
     //삭제할 이모션객체 다짐넘버 null로 수정
     public void updateNull(){
-        this.dajimNumber = null;
+        this.sticker = null;
     }
 
 }

--- a/src/main/java/challenge/nDaysChallenge/dto/response/EmotionResponseDto.java
+++ b/src/main/java/challenge/nDaysChallenge/dto/response/EmotionResponseDto.java
@@ -4,27 +4,29 @@ import challenge.nDaysChallenge.domain.Member;
 import challenge.nDaysChallenge.domain.dajim.Emotion;
 import challenge.nDaysChallenge.domain.dajim.Sticker;
 import lombok.*;
+import org.springframework.lang.Nullable;
+
+import javax.validation.constraints.Null;
 
 @Getter
 @NoArgsConstructor
 public class EmotionResponseDto {
 
-    private long dajimNumber; //좋아요 등록한 다짐 넘버
+    private Long dajimNumber; //좋아요 등록한 다짐 넘버
 
     private String memberNickname;//좋아요 등록한 멤버 닉네임
 
     private String sticker; //선택한 감정스티커
 
-    @Builder
     public EmotionResponseDto(long dajimNumber, String memberNickname, String sticker){
-        this.dajimNumber=dajimNumber;
-        this.memberNickname=memberNickname;
-        this.sticker=sticker;
+        this.dajimNumber = dajimNumber;
+        this.memberNickname = memberNickname;
+        this.sticker = sticker;
     }
 
-    @Builder
-    public EmotionResponseDto(String sticker){
-        this.sticker=sticker;
+    //삭제할 이모션객체 다짐넘버 null로 수정
+    public void updateNull(){
+        this.dajimNumber = null;
     }
 
 }

--- a/src/main/java/challenge/nDaysChallenge/service/dajim/EmotionService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/dajim/EmotionService.java
@@ -39,7 +39,8 @@ public class EmotionService {
         EmotionResponseDto emotionResponseDto = new EmotionResponseDto(
                 emotionRequestDto.getDajimNumber(),
                 member.getNickname(),
-                emotionRequestDto.getSticker());
+                emotionRequestDto.getSticker()
+        );
 
         //이모션 객체 등록 (레포지토리에서 객체 못 찾았을 때)
         if (!emotion.isPresent()){
@@ -49,17 +50,20 @@ public class EmotionService {
 
         //스티커 수정 (다른 스티커 클릭 시)
         Emotion emotionForUpdate = emotion.get();
+        Sticker stickerBeforeUpdate = emotionForUpdate.getSticker();
         LocalDateTime beforeUpdate = emotionForUpdate.getUpdatedDate(); //수정 전 마지막 업데이트 시간 저장해두기
 
-        Emotion updatedEmotion = emotionForUpdate.update(emotion.get().getSticker()); //수정 반영
+        Emotion updatedEmotion = emotionForUpdate.update(Sticker.valueOf(emotionRequestDto.getSticker())); //수정 반영
 
         //이모션 객체 삭제 (동일 스티커 클릭해서 업데이트 안 됐을 때)
         LocalDateTime afterUpdate = updatedEmotion.getUpdatedDate();
-        if (beforeUpdate==afterUpdate){ //수정 전 시간 = 수정 후 시간
+        if (beforeUpdate.isEqual(afterUpdate) && //업데이트 X & 똑같은 스티커 클릭 시
+                stickerBeforeUpdate.toString().equals(emotionRequestDto.getSticker())){
+
             emotionRepository.delete(updatedEmotion);
             dajim.deleteEmotions(updatedEmotion);
 
-            emotionResponseDto.builder().sticker(null);
+            emotionResponseDto.updateNull();
         }
 
         return emotionResponseDto;

--- a/src/test/java/challenge/nDaysChallenge/dajim/EmotionRepositoryTest.java
+++ b/src/test/java/challenge/nDaysChallenge/dajim/EmotionRepositoryTest.java
@@ -125,9 +125,6 @@ public class EmotionRepositoryTest {
         //when
         Emotion updatedEmotion = emotionFound.update(Sticker.CHEER); //수정
 
-        dajim.deleteEmotions(emotionFound);
-        dajim.addEmotions(updatedEmotion);
-
         //then
         assertThat(updatedEmotion.getSticker().toString()).isEqualTo("CHEER");
         assertThat(dajim.getEmotions().get(0)).isEqualTo(updatedEmotion);
@@ -144,14 +141,17 @@ public class EmotionRepositoryTest {
                 .orElseThrow(()->new RuntimeException("다짐을 찾을 수 없습니다"));
 
         Optional<Emotion> emotion = emotionRepository.findByDajimAndMember(1L, 1L);
+
         Emotion emotionFound = emotion.get();
+        Sticker stickerBeforeUpdate = emotionFound.getSticker(); //업데이트 전 스티커
         LocalDateTime beforeUpdate = emotionFound.getUpdatedDate(); //업데이트 전 시간
 
         //when
         Emotion updatedEmotion = emotionFound.update(Sticker.SURPRISE); //똑같은 스티커 클릭 시
 
         LocalDateTime afterUpdate = updatedEmotion.getUpdatedDate(); //업데이트 후 시간
-        if (beforeUpdate==afterUpdate){ //수정 전후 시간 같으면 (=똑같은 스티커 클릭) 삭제
+        if (beforeUpdate.isEqual(afterUpdate) && //업데이트 X & 똑같은 스티커 클릭 시
+                stickerBeforeUpdate.toString().equals(updatedEmotion.getSticker().toString())){
             emotionRepository.delete(updatedEmotion);
             dajim.deleteEmotions(updatedEmotion);
         }


### PR DESCRIPTION
- 수정 시 삭제 처리됨 
  - 이모션 첫 등록 시 createdDate, updatedDate 같은 것 고려 못함 => 업데이트 전, 후 스티커 비교 조건 추가
  - 타입에 따른 비교 메소드 변경 => LocalDateTime : isEqual(), String: equals()
- EmotionResponseDto의 다짐넘버에 null이 담기지 않음
  - 다짐넘버 타입 Long으로 변경
  - dto 내에 다짐넘버 null 담는 메소드 추가
- ResponseDto null 처리 필드 변경 (다짐넘버 -> 스티커)