### PR TITLE
닉네임, 아이디 중복 체크 메소드 변경 및 회원가입요청dto 제약조건, 오류 메시지 설정

### DIFF
--- a/src/main/java/challenge/nDaysChallenge/controller/AuthController.java
+++ b/src/main/java/challenge/nDaysChallenge/controller/AuthController.java
@@ -10,7 +10,12 @@ import challenge.nDaysChallenge.service.jwt.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,21 +25,25 @@ public class AuthController { //회원가입 & 로그인 & 토큰 재발급
 
     //회원가입
     @PostMapping("/auth/signup")
-    public ResponseEntity<MemberResponseDto> signup(@RequestBody MemberRequestDto memberRequestDto){
+    public ResponseEntity<?> signup(@Valid @RequestBody MemberRequestDto memberRequestDto, BindingResult bindingResult){
+        if (bindingResult.hasErrors()) {
+           return ResponseEntity.badRequest().body(bindingResult.getFieldErrors());
+        }
+
         MemberResponseDto memberResponseDto = authService.signup(memberRequestDto);
         return ResponseEntity.ok().body(memberResponseDto);
     }
 
-    //아이디 중복 검사
+    //아이디 중복 검사 (ok = 중복 아님 / exists = 중복)
     @GetMapping("/auth/id-check")
-    public ResponseEntity<Boolean> idCheck (@RequestBody String id){
+    public ResponseEntity<String> idCheck (@RequestBody String id){
         return ResponseEntity.ok().body(authService.idCheck(id));
     }
 
 
     //닉네임 중복 검사
     @GetMapping("/auth/nickname-check")
-    public ResponseEntity<Boolean> nicknameCheck (@RequestBody String nickname){
+    public ResponseEntity<String> nicknameCheck (@RequestBody String nickname){
         return ResponseEntity.ok().body(authService.nicknameCheck(nickname));
     }
 

--- a/src/main/java/challenge/nDaysChallenge/domain/Member.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/Member.java
@@ -6,7 +6,10 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.UniqueElements;
+
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/challenge/nDaysChallenge/domain/Member.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/Member.java
@@ -23,11 +23,12 @@ public class Member {
     @Column(name = "member_number")
     private Long number;
 
-    @Column(name = "member_id")
+    @Column(name = "member_id", unique = true)
     private String id;
 
     private String pw;
 
+    @Column(unique = true)
     private String nickname;
 
     private int image;

--- a/src/main/java/challenge/nDaysChallenge/dto/request/member/MemberRequestDto.java
+++ b/src/main/java/challenge/nDaysChallenge/dto/request/member/MemberRequestDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 
 @Getter
@@ -17,12 +18,17 @@ import javax.validation.constraints.NotBlank;
 @NoArgsConstructor
 public class MemberRequestDto {
 
+    @NotBlank(message = "이메일을 입력해 주세요.")
+    @Email(message = "이메일 형식이 아닙니다.")
     private String id;
 
+    @NotBlank(message = "비밀번호를 입력해 주세요.")
     private String pw;
 
+    @NotBlank(message = "닉네임을 입력해 주세요.")
     private String nickname;
 
+    @NotBlank(message = "프로필 사진을 선택해 주세요.")
     private int image;
 
     private int roomLimit;

--- a/src/main/java/challenge/nDaysChallenge/repository/member/MemberRepository.java
+++ b/src/main/java/challenge/nDaysChallenge/repository/member/MemberRepository.java
@@ -19,10 +19,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     //닉네임으로 유저찾기
     Optional<Member> findByNickname(String nickname);
 
-    //중복 가입 방지
+    //아이디 중복 체크
     boolean existsById(String id);
 
-    //중복 닉네임 방지
+    //닉네임 중복 체크
     boolean existsByNickname(String nickname);
 
     Optional<Member> findByNumber(Long memberNumber);

--- a/src/main/java/challenge/nDaysChallenge/service/jwt/AuthService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/jwt/AuthService.java
@@ -48,22 +48,22 @@ public class AuthService { //회원가입 & 로그인 & 토큰 재발급
     public String idCheck(String id){
         boolean exists = memberRepository.existsById(id);
 
-        if (exists==false){
-            return "ok";
-        } else {
+        if (exists){
             return "exists";
+        } else {
+            return "ok";
         }
     }
 
     //닉네임 중복 검사
     @Transactional(readOnly = true)
     public String nicknameCheck(String nickname){
-        boolean exists = memberRepository.existsById(nickname);
+        boolean exists = memberRepository.existsByNickname(nickname);
 
-        if (exists==false){
-            return "ok";
-        } else {
+        if (exists){
             return "exists";
+        } else {
+            return "ok";
         }
     }
 

--- a/src/main/java/challenge/nDaysChallenge/service/jwt/AuthService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/jwt/AuthService.java
@@ -19,6 +19,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.Errors;
+
+import javax.validation.Valid;
 
 @Service
 @RequiredArgsConstructor
@@ -33,7 +36,7 @@ public class AuthService { //회원가입 & 로그인 & 토큰 재발급
     private final RefreshTokenRepository refreshTokenRepository;
 
     //회원가입
-    public MemberResponseDto signup(MemberRequestDto memberRequestDto) {
+    public MemberResponseDto signup(@Valid MemberRequestDto memberRequestDto) {
         Member member = memberRequestDto.toMember(passwordEncoder);
         memberRepository.save(member);
 
@@ -42,18 +45,26 @@ public class AuthService { //회원가입 & 로그인 & 토큰 재발급
 
     //아이디 중복 검사
     @Transactional(readOnly = true)
-    public boolean idCheck(String id){
+    public String idCheck(String id){
         boolean exists = memberRepository.existsById(id);
 
-        return exists;
+        if (exists==false){
+            return "ok";
+        } else {
+            return "exists";
+        }
     }
 
     //닉네임 중복 검사
     @Transactional(readOnly = true)
-    public boolean nicknameCheck(String nickname){
+    public String nicknameCheck(String nickname){
         boolean exists = memberRepository.existsById(nickname);
 
-        return exists;
+        if (exists==false){
+            return "ok";
+        } else {
+            return "exists";
+        }
     }
 
     //로그인

--- a/src/test/java/challenge/nDaysChallenge/member/CheckIdAndNickname.java
+++ b/src/test/java/challenge/nDaysChallenge/member/CheckIdAndNickname.java
@@ -1,0 +1,77 @@
+package challenge.nDaysChallenge.member;
+
+import challenge.nDaysChallenge.domain.Member;
+import challenge.nDaysChallenge.dto.request.member.MemberRequestDto;
+import challenge.nDaysChallenge.repository.member.MemberRepository;
+import challenge.nDaysChallenge.service.jwt.AuthService;
+import challenge.nDaysChallenge.service.member.MemberService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.transaction.BeforeTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class CheckIdAndNickname {
+
+    @InjectMocks
+    AuthService authService;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @BeforeTransaction
+    @Transactional
+    public void 회원가입(){
+        //given
+        MemberRequestDto memberRequestDto = new MemberRequestDto("abc@naver.com","123","aaa",1,2);
+        Member member = memberRequestDto.toMember(passwordEncoder);
+        given(memberRepository.save(any())).willReturn(member);
+    }
+
+    @Test
+    void 아이디_중복_검사(){
+        //mocking
+        given(memberRepository.existsById("abc@naver.com")).willReturn(true);
+        given(memberRepository.existsById("abcd@naver.com")).willReturn(false);
+
+        //when
+        String id = authService.idCheck("abc@naver.com");
+        String id2 = authService.idCheck("abcd@naver.com");
+
+        //then
+        assertThat(id).isEqualTo("exists");
+        assertThat(id2).isEqualTo("ok");
+
+    }
+
+    @Test
+    void 닉네임_중복_검사(){
+        //mocking
+        given(memberRepository.existsByNickname("aaa")).willReturn(true);
+        given(memberRepository.existsByNickname("aaab")).willReturn(false);
+
+        //when
+        String nickname = authService.nicknameCheck("aaa");
+        String nickname2 = authService.nicknameCheck("aaab");
+
+        //then
+        assertThat(nickname).isEqualTo("exists");
+        assertThat(nickname2).isEqualTo("ok");
+    }
+
+}

--- a/src/test/java/challenge/nDaysChallenge/member/memberTest.java
+++ b/src/test/java/challenge/nDaysChallenge/member/memberTest.java
@@ -15,10 +15,13 @@ import challenge.nDaysChallenge.repository.RoomMemberRepository;
 import challenge.nDaysChallenge.repository.dajim.DajimRepository;
 import challenge.nDaysChallenge.repository.dajim.EmotionRepository;
 import challenge.nDaysChallenge.repository.room.RoomRepository;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.transaction.BeforeTransaction;
@@ -27,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 public class memberTest {
@@ -50,11 +54,20 @@ public class memberTest {
 
     @BeforeTransaction
     @Transactional
-    @Rollback(value = false)
     public void 회원가입(){
         MemberRequestDto memberRequestDto = new MemberRequestDto("abc@naver.com","123","aaa",1,2);
         Member member = memberRequestDto.toMember(passwordEncoder);
         memberRepository.save(member);
+    }
+
+    @DisplayName("중복 닉네임 가입")
+    @Test
+    @Transactional
+    void 중복_닉네임_가입_확인(){
+        MemberRequestDto memberRequestDto = new MemberRequestDto("abc1@naver.com","123","aaa",1,2);
+        Member member = memberRequestDto.toMember(passwordEncoder);
+
+        assertThrows(DataIntegrityViolationException.class, ()->memberRepository.save(member));
     }
 
     @DisplayName("닉네임 중복 확인")

--- a/src/test/java/challenge/nDaysChallenge/member/memberTest.java
+++ b/src/test/java/challenge/nDaysChallenge/member/memberTest.java
@@ -1,4 +1,4 @@
-package challenge.nDaysChallenge.jwt;
+package challenge.nDaysChallenge.member;
 
 import challenge.nDaysChallenge.domain.Authority;
 import challenge.nDaysChallenge.domain.Member;
@@ -65,6 +65,19 @@ public class memberTest {
         //닉네임 중복 확인
         boolean exists = memberRepository.existsByNickname("aaa");
         boolean exists2 = memberRepository.existsByNickname("new");
+
+        assertThat(exists).isEqualTo(true);
+        assertThat(exists2).isEqualTo(false);
+    }
+
+    @DisplayName("아이디 중복 확인")
+    @Test
+    @Transactional
+    @Rollback(value = false)
+    void 아이디_중복확인(){
+        //닉네임 중복 확인
+        boolean exists = memberRepository.existsById("abc@naver.com");
+        boolean exists2 = memberRepository.existsById("aaa@naver.com");
 
         assertThat(exists).isEqualTo(true);
         assertThat(exists2).isEqualTo(false);


### PR DESCRIPTION
- 닉네임, 아이디 중복 체크 메소드 변경
  - 리턴값 boolean => 문자열 (ok / exists) 으로 수정
  - 테스트 완료
-  MemberRequestDto 수정
    -  NotBlank, Email 등 형식 조건 추가
- Member 엔티티 수정 
  - id, nickname 컬럼 유니크 제약조건 추가
  - 테스트 완료