### PR TITLE
그룹 챌린지 스탬프 생성 시 오류 코드 수정

### DIFF
--- a/src/main/java/challenge/nDaysChallenge/controller/ReportController.java
+++ b/src/main/java/challenge/nDaysChallenge/controller/ReportController.java
@@ -1,12 +1,15 @@
 package challenge.nDaysChallenge.controller;
 
 import challenge.nDaysChallenge.domain.Report;
+import challenge.nDaysChallenge.domain.member.Member;
+import challenge.nDaysChallenge.domain.member.MemberAdapter;
 import challenge.nDaysChallenge.dto.request.ReportRequestDto;
 import challenge.nDaysChallenge.dto.response.ReportResponseDto;
 import challenge.nDaysChallenge.service.ReportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,7 +22,10 @@ public class ReportController {
 
     //신고 생성
     @PostMapping("/feed/report")
-    public ResponseEntity<?> report(@RequestBody ReportRequestDto dto) {
+    public ResponseEntity<?> report(@AuthenticationPrincipal MemberAdapter memberAdapter,
+                                    @RequestBody ReportRequestDto dto) {
+
+        checkLogin(memberAdapter.getMember());
 
         Report report = reportService.report(dto.getDajim(), dto.getCause(), dto.getIsDajim(), dto.getContent());
         ReportResponseDto savedReport = ReportResponseDto.builder()
@@ -31,5 +37,12 @@ public class ReportController {
                 .build();
 
         return ResponseEntity.status(HttpStatus.CREATED).body(savedReport);
+    }
+
+    //로그인 검증
+    private void checkLogin(Member member) {
+        if (member == null) {
+            throw new RuntimeException("로그인한 멤버만 사용할 수 있습니다.");
+        }
     }
 }

--- a/src/main/java/challenge/nDaysChallenge/controller/ReportController.java
+++ b/src/main/java/challenge/nDaysChallenge/controller/ReportController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.net.URI;
+
 @RestController
 @RequiredArgsConstructor
 public class ReportController {
@@ -36,7 +38,9 @@ public class ReportController {
                 .dajim(report.getDajim().getNumber())
                 .build();
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(savedReport);
+        URI location = URI.create("/feed/report" + report.getNumber());
+
+        return ResponseEntity.status(HttpStatus.CREATED).location(location).body(savedReport);
     }
 
     //로그인 검증

--- a/src/main/java/challenge/nDaysChallenge/domain/Stamp.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/Stamp.java
@@ -1,7 +1,6 @@
 package challenge.nDaysChallenge.domain;
 
 import challenge.nDaysChallenge.domain.room.Room;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/challenge/nDaysChallenge/domain/Stamp.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/Stamp.java
@@ -53,13 +53,14 @@ public class Stamp {
     public int day30;
 
 
-    //생성메서드
+    //생성 메서드
     public static Stamp createStamp(Room room) {
         Stamp stamp = new Stamp();
         stamp.room = room;
         return stamp;
     }
 
+    //스탬프 찍기
     public Stamp updateStamp(Room room, int day1, int day2, int day3, int day4, int day5, int day6, int day7, int day8, int day9, int day10, int day11, int day12, int day13, int day14, int day15, int day16, int day17, int day18, int day19, int day20, int day21, int day22, int day23, int day24, int day25, int day26, int day27, int day28, int day29, int day30) {
         this.room = room;
         this.day1 = day1;

--- a/src/main/java/challenge/nDaysChallenge/domain/member/Member.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/member/Member.java
@@ -42,10 +42,10 @@ public class Member {
     private  List<Relationship> confirmedFriendsList = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private final List<RoomMember> roomMemberList = new ArrayList<>();
+    private List<RoomMember> roomMemberList = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private final List<SingleRoom> singleRooms = new ArrayList<>();
+    private List<SingleRoom> singleRooms = new ArrayList<>();
 
     @Builder
     public Member(String id, String pw ,String nickname, int image, int roomLimit, Authority authority) {

--- a/src/main/java/challenge/nDaysChallenge/domain/room/GroupRoom.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/room/GroupRoom.java
@@ -6,7 +6,9 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Entity
 @Getter
@@ -15,6 +17,12 @@ public class GroupRoom extends Room {
 
     @OneToMany(mappedBy = "room")
     private List<RoomMember> roomMemberList = new ArrayList<>();
+    @ElementCollection
+    private Map<String, Long> stamps = new HashMap<>();
+
+    public void addStamps(Map<String, Long> stamps) {
+        this.stamps = stamps;
+    }
 
     //==생성자==//
     public GroupRoom(String name, Period period, Category category, int passCount, String reward, int usedPassCount, int successCount) {

--- a/src/main/java/challenge/nDaysChallenge/domain/room/GroupRoom.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/room/GroupRoom.java
@@ -1,5 +1,6 @@
 package challenge.nDaysChallenge.domain.room;
 
+import challenge.nDaysChallenge.domain.member.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,17 +16,21 @@ import java.util.Map;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupRoom extends Room {
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_number")
+    private Member member;
+
     @OneToMany(mappedBy = "room")
     private List<RoomMember> roomMemberList = new ArrayList<>();
     @ElementCollection
+    @CollectionTable(joinColumns = @JoinColumn(name = "room_number"))
+    @Column(name = "stamp_number")
     private Map<String, Long> stamps = new HashMap<>();
 
-    public void addStamps(Map<String, Long> stamps) {
-        this.stamps = stamps;
-    }
 
     //==생성자==//
-    public GroupRoom(String name, Period period, Category category, int passCount, String reward, int usedPassCount, int successCount) {
+    public GroupRoom(Member member, String name, Period period, Category category, int passCount, String reward, int usedPassCount, int successCount) {
+        this.member = member;
         this.name = name;
         this.period = period;
         this.category = category;

--- a/src/main/java/challenge/nDaysChallenge/domain/room/RoomMember.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/room/RoomMember.java
@@ -21,7 +21,7 @@ public class RoomMember {
     @JoinColumn(name = "member_number")
     private Member member;
 
-    @ManyToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "room_number")
     private Room room;
 

--- a/src/main/java/challenge/nDaysChallenge/dto/request/StampDto.java
+++ b/src/main/java/challenge/nDaysChallenge/dto/request/StampDto.java
@@ -1,11 +1,13 @@
 package challenge.nDaysChallenge.dto.request;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class StampDto {
 
     public Long roomNumber;
@@ -41,38 +43,4 @@ public class StampDto {
     public int day29;
     public int day30;
 
-    public StampDto(Long roomNumber, Long stampNumber, int day1, int day2, int day3, int day4, int day5, int day6, int day7, int day8, int day9, int day10, int day11, int day12, int day13, int day14, int day15, int day16, int day17, int day18, int day19, int day20, int day21, int day22, int day23, int day24, int day25, int day26, int day27, int day28, int day29, int day30) {
-        this.roomNumber = roomNumber;
-        this.stampNumber = stampNumber;
-        this.day1 = day1;
-        this.day2 = day2;
-        this.day3 = day3;
-        this.day4 = day4;
-        this.day5 = day5;
-        this.day6 = day6;
-        this.day7 = day7;
-        this.day8 = day8;
-        this.day9 = day9;
-        this.day10 = day10;
-        this.day11 = day11;
-        this.day12 = day12;
-        this.day13 = day13;
-        this.day14 = day14;
-        this.day15 = day15;
-        this.day16 = day16;
-        this.day17 = day17;
-        this.day18 = day18;
-        this.day19 = day19;
-        this.day20 = day20;
-        this.day21 = day21;
-        this.day22 = day22;
-        this.day23 = day23;
-        this.day24 = day24;
-        this.day25 = day25;
-        this.day26 = day26;
-        this.day27 = day27;
-        this.day28 = day28;
-        this.day29 = day29;
-        this.day30 = day30;
-    }
 }

--- a/src/main/java/challenge/nDaysChallenge/dto/response/Room/GroupRoomResponseDto.java
+++ b/src/main/java/challenge/nDaysChallenge/dto/response/Room/GroupRoomResponseDto.java
@@ -2,9 +2,11 @@ package challenge.nDaysChallenge.dto.response.Room;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
+import net.minidev.json.JSONObject;
 
 import java.time.LocalDate;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 @Getter
@@ -19,7 +21,6 @@ public class GroupRoomResponseDto {
     private int passCount;
     private String type;
     private String status;
-    private Long stamp;
 
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate startDate;
@@ -28,16 +29,16 @@ public class GroupRoomResponseDto {
     private Long totalDays;
 
     private Set<Long> groupMembers = new HashSet<>();
+    private JSONObject jsonObject;
 
     @Builder
-    public GroupRoomResponseDto(Long roomNumber, String name, String category, String reward, int passCount, String type, String status, Long stamp, LocalDate startDate, LocalDate endDate, Long totalDays, Set<Long> groupMembers) {
+    public GroupRoomResponseDto(Long roomNumber, String name, String category, String reward, int passCount, String type, String status, LocalDate startDate, LocalDate endDate, Long totalDays, Set<Long> groupMembers, Map<String, Long> memberStamps) {
         this.roomNumber = roomNumber;
         this.name = name;
         this.category = category;
         this.reward = reward;
         this.type = type;
         this.status = status;
-        this.stamp = stamp;
         this.passCount = passCount;
         this.totalDays = totalDays;
         this.startDate = startDate;
@@ -45,6 +46,8 @@ public class GroupRoomResponseDto {
         for (Long members : groupMembers) {
             this.groupMembers.add(members);
         }
+        jsonObject = new JSONObject(memberStamps);
+
     }
 
 }

--- a/src/main/java/challenge/nDaysChallenge/repository/StampRepository.java
+++ b/src/main/java/challenge/nDaysChallenge/repository/StampRepository.java
@@ -1,11 +1,15 @@
 package challenge.nDaysChallenge.repository;
 
 import challenge.nDaysChallenge.domain.Stamp;
+import challenge.nDaysChallenge.domain.room.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StampRepository extends JpaRepository<Stamp, Long> {
 
-
+    @Query("select s from Stamp s where s.room = :room")
+    public Stamp findByRoom(@Param("room") Room room);
 }

--- a/src/main/java/challenge/nDaysChallenge/repository/room/SingleRoomRepository.java
+++ b/src/main/java/challenge/nDaysChallenge/repository/room/SingleRoomRepository.java
@@ -17,7 +17,7 @@ public interface SingleRoomRepository extends JpaRepository<SingleRoom, Long> {
                     " and s.status = 'CONTINUE'")
     public List<SingleRoom> findSingleRooms(@Param("member") Member member);
 
-    //완료 개인 챌린지
+    //완료 개인 챌린지r
     @Query(value = "select s from SingleRoom s" +
                     " where s.member = :member" +
                     " and s.status = 'END'")

--- a/src/main/java/challenge/nDaysChallenge/service/RoomService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/RoomService.java
@@ -90,16 +90,26 @@ public class RoomService {
         //저장
         groupRoomRepository.save(newRoom);
 
-        //챌린지 멤버 생성&저장
+        //방장 생성&저장
         Stamp stamp = Stamp.createStamp(newRoom);
         stampRepository.save(stamp);
         RoomMember roomMember = RoomMember.createRoomMember(member, newRoom, stamp);  //방장
         roomMemberRepository.save(roomMember);
-        for (Member members : memberList) {  //그 외 멤버
-            Stamp memberStamp = Stamp.createStamp(newRoom);
-            stampRepository.save(memberStamp);
-            RoomMember result = RoomMember.createRoomMember(members, newRoom, memberStamp);
+
+        Map<String, Long> stamps = newRoom.getStamps();
+        stamps.put(member.getId(), stamp.getNumber());
+
+        //그 외 멤버 생성&저장
+        for (Member members : memberList) {
+            Stamp newStamp = Stamp.createStamp(newRoom);
+            stampRepository.save(newStamp);
+            RoomMember result = RoomMember.createRoomMember(members, newRoom, newStamp);
             roomMemberRepository.save(result);
+
+            for (Long memberNumber : selectedMember) {
+                RoomMember findRoomMember = roomMemberRepository.findByMemberAndRoom(memberRepository.findByNumber(memberNumber).get(), newRoom);
+                stamps.put(findRoomMember.getMember().getId(), newStamp.getNumber());
+            }
         }
 
         return newRoom;

--- a/src/main/java/challenge/nDaysChallenge/service/RoomService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/RoomService.java
@@ -85,31 +85,27 @@ public class RoomService {
         }
 
         //챌린지 생성
-        GroupRoom newRoom = new GroupRoom(name, new Period(period.getStartDate(), period.getTotalDays()), category, passCount, reward, usedPassCount, successCount);
-
-        //저장
+        GroupRoom newRoom = new GroupRoom(member, name, new Period(period.getStartDate(), period.getTotalDays()), category, passCount, reward, usedPassCount, successCount);
         groupRoomRepository.save(newRoom);
 
-        //방장 생성&저장
+        //방장 - 스탬프, 룸멤버 생성
         Stamp stamp = Stamp.createStamp(newRoom);
         stampRepository.save(stamp);
-        RoomMember roomMember = RoomMember.createRoomMember(member, newRoom, stamp);  //방장
+        RoomMember roomMember = RoomMember.createRoomMember(member, newRoom, stamp);
         roomMemberRepository.save(roomMember);
 
         Map<String, Long> stamps = newRoom.getStamps();
         stamps.put(member.getId(), stamp.getNumber());
 
-        //그 외 멤버 생성&저장
-        for (Member members : memberList) {
+        //그 외 멤버 - 스탬프, 룸멤버 생성
+        for (Member fidnMember : memberList) {
             Stamp newStamp = Stamp.createStamp(newRoom);
             stampRepository.save(newStamp);
-            RoomMember result = RoomMember.createRoomMember(members, newRoom, newStamp);
+            RoomMember result = RoomMember.createRoomMember(fidnMember, newRoom, newStamp);
             roomMemberRepository.save(result);
 
-            for (Long memberNumber : selectedMember) {
-                RoomMember findRoomMember = roomMemberRepository.findByMemberAndRoom(memberRepository.findByNumber(memberNumber).get(), newRoom);
-                stamps.put(findRoomMember.getMember().getId(), newStamp.getNumber());
-            }
+            RoomMember findRoomMember = roomMemberRepository.findByMemberAndRoom(memberRepository.findByNumber(fidnMember.getNumber()).get(), newRoom);
+            stamps.put(findRoomMember.getMember().getId(), newStamp.getNumber());
         }
 
         return newRoom;

--- a/src/main/resources/application-mysql.yml
+++ b/src/main/resources/application-mysql.yml
@@ -3,7 +3,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/challenge?useSSL=false&allowPublicKeyRetrieval=true
     username: root
-    password: '1234'
+    password: '12345678'
 
     hikari:
       initialization-fail-timeout: 0 #커넥션 초기화 실패 시 유효성 검사 시도

--- a/src/test/java/challenge/nDaysChallenge/Room/RoomQueryTest.java
+++ b/src/test/java/challenge/nDaysChallenge/Room/RoomQueryTest.java
@@ -108,7 +108,7 @@ public class RoomQueryTest {
     List<GroupRoom> makeGroupRooms() {
         List<GroupRoom> groupRooms = new ArrayList<>();
         for (int i = 0; i < 9; i++) {
-            GroupRoom groupRoom = new GroupRoom("명상", new Period(LocalDate.now(), 30L), Category.MINDFULNESS, 20, "여행", 0, 0);
+            GroupRoom groupRoom = new GroupRoom(member, "명상", new Period(LocalDate.now(), 30L), Category.MINDFULNESS, 20, "여행", 0, 0);
             groupRooms.add(groupRoom);
         }
         groupRoomRepository.saveAll(groupRooms);

--- a/src/test/java/challenge/nDaysChallenge/Room/RoomServiceTest.java
+++ b/src/test/java/challenge/nDaysChallenge/Room/RoomServiceTest.java
@@ -150,10 +150,13 @@ public class RoomServiceTest {
     @Rollback(value = true)
     public void 진행_챌린지_조회() throws Exception {
         //given
+        Member member = new Member("user@naver.com", "12345", "nick", 1, 4, Authority.ROLE_USER);
+        memberRepository.save(member);
+
         SingleRoom singleRoom1 = new SingleRoom("기상", period, Category.ROUTINE, 2, "", 0, 0);
         SingleRoom singleRoom2 = new SingleRoom("공부", period, Category.ETC, 0, "", 0, 0);
         SingleRoom singleRoom3 = new SingleRoom("청소", period, Category.EXERCISE, 10, "꿀잠", 0, 0);
-        GroupRoom groupRoom = new GroupRoom("명상", period, Category.MINDFULNESS, 20, "여행", 0, 0);
+        GroupRoom groupRoom = new GroupRoom(member, "명상", period, Category.MINDFULNESS, 20, "여행", 0, 0);
         singleRoomRepository.save(singleRoom1);
         singleRoomRepository.save(singleRoom2);
         singleRoomRepository.save(singleRoom3);
@@ -163,9 +166,6 @@ public class RoomServiceTest {
         Stamp stamp2 = Stamp.createStamp(singleRoom2);
         Stamp stamp3 = Stamp.createStamp(singleRoom3);
         Stamp stamp4 = Stamp.createStamp(groupRoom);
-
-        Member member = new Member("user@naver.com", "12345", "nick", 1, 4, Authority.ROLE_USER);
-        memberRepository.save(member);
 
         SingleRoom createSingleRoom1 = singleRoom1.addRoom(singleRoom1, member, stamp1);
         SingleRoom createSingleRoom2 = singleRoom2.addRoom(singleRoom2, member, stamp2);
@@ -235,11 +235,11 @@ public class RoomServiceTest {
     @Rollback(value = true)
     public void 완료_그룹챌린지_리스트() throws Exception {
         //given
-        GroupRoom groupRoom = new GroupRoom("명상", period, Category.MINDFULNESS, 20, "여행", 0, 0);
-        groupRoomRepository.save(groupRoom);
-
         Member member = new Member("user@naver.com", "12345", "nick", 1, 4, Authority.ROLE_USER);
         memberRepository.save(member);
+
+        GroupRoom groupRoom = new GroupRoom(member, "명상", period, Category.MINDFULNESS, 20, "여행", 0, 0);
+        groupRoomRepository.save(groupRoom);
 
         RoomMember roomMember = RoomMember.createRoomMember(member, groupRoom, Stamp.createStamp(groupRoom));
         roomMemberRepository.save(roomMember);

--- a/src/test/java/challenge/nDaysChallenge/dajim/DajimFeedRepositoryTest.java
+++ b/src/test/java/challenge/nDaysChallenge/dajim/DajimFeedRepositoryTest.java
@@ -100,7 +100,7 @@ public class DajimFeedRepositoryTest {
                 .build());
 
         //그룹룸 (룸2-멤버1,2,3)
-        GroupRoom room2 = new GroupRoom("GroupRoom", new Period(LocalDate.now(),100L), Category.ETC, 3, "", 0, 0);
+        GroupRoom room2 = new GroupRoom(member1, "GroupRoom", new Period(LocalDate.now(),100L), Category.ETC, 3, "", 0, 0);
         roomRepository.save(room2);
         RoomMember roomMember1 = RoomMember.createRoomMember(member1, room2, Stamp.createStamp(room2));
         RoomMember roomMember2 = RoomMember.createRoomMember(member2, room2, Stamp.createStamp(room2));

--- a/src/test/java/challenge/nDaysChallenge/dajim/DajimRepositoryTest.java
+++ b/src/test/java/challenge/nDaysChallenge/dajim/DajimRepositoryTest.java
@@ -27,9 +27,9 @@ class DajimRepositoryTest {
     @Test
     void saveDajim(){
         //given
-        GroupRoom room = new GroupRoom("newRoom",new Period(LocalDate.now(),100L), Category.ROUTINE,4,"보상", 0, 0);
-
         Member member = new Member("user@naver.com","12345","userN",1,4, Authority.ROLE_USER);
+
+        GroupRoom room = new GroupRoom(member, "newRoom",new Period(LocalDate.now(),100L), Category.ROUTINE,4,"보상", 0, 0);
 
         //when
         DajimUploadRequestDto dajimUploadRequestDto = new DajimUploadRequestDto("다짐 내용", "PUBLIC");
@@ -57,9 +57,9 @@ class DajimRepositoryTest {
     @Test
     void modifyDajim(){
         //given
-        GroupRoom room = new GroupRoom("newRoom",new Period(LocalDate.now(),100L), Category.ROUTINE,4,"보상", 0, 0);
-
         Member member = new Member("user@naver.com","12345","userN",1,4, Authority.ROLE_USER);
+
+        GroupRoom room = new GroupRoom(member, "newRoom",new Period(LocalDate.now(),100L), Category.ROUTINE,4,"보상", 0, 0);
         DajimUploadRequestDto dajimUploadRequestDto = new DajimUploadRequestDto("다짐 내용", "PUBLIC");
         Dajim dajim = Dajim.builder()
                 .room(room)
@@ -83,7 +83,7 @@ class DajimRepositoryTest {
         //given
         Member member = new Member("user@naver.com","12345","userN",1,4, Authority.ROLE_USER);
         Member member2 = new Member("user2@naver.com","12345","userN2",1,4, Authority.ROLE_USER);
-        GroupRoom room = new GroupRoom("newRoom",new Period(LocalDate.now(),100L), Category.ROUTINE,4, "", 0, 0);
+        GroupRoom room = new GroupRoom(member, "newRoom",new Period(LocalDate.now(),100L), Category.ROUTINE,4, "", 0, 0);
 
         DajimUploadRequestDto dajimUploadRequestDto = new DajimUploadRequestDto("다짐 내용", "PUBLIC");
 

--- a/src/test/java/challenge/nDaysChallenge/dajim/QueryTest.java
+++ b/src/test/java/challenge/nDaysChallenge/dajim/QueryTest.java
@@ -98,7 +98,7 @@ public class QueryTest { //N+1 테스트
                 .build());
 
         //그룹룸 (룸2-멤버1,2,3)
-        GroupRoom room2 = new GroupRoom("GroupRoom", new Period(LocalDate.now(),100L), Category.ETC, 3, "", 0, 0);
+        GroupRoom room2 = new GroupRoom(member1, "GroupRoom", new Period(LocalDate.now(),100L), Category.ETC, 3, "", 0, 0);
         roomRepository.save(room2);
         RoomMember roomMember1 = RoomMember.createRoomMember(member1, room2, Stamp.createStamp(room2));
         RoomMember roomMember2 = RoomMember.createRoomMember(member2, room2, Stamp.createStamp(room2));


### PR DESCRIPTION
- 그룹 챌린지 생성 시 member_number 컬럼에 방장 정보 추가되게 변경
- 그룹 챌린지에서 멤버 별 스탬프 구분 위해 Map으로 키: 멤버 id, 값: 스탬프번호 저장되게 변경
- api 주소 리소스 중심으로 변경