### PR TITLE
feat: successCount와 usedPassCount db에 반영

### DIFF
--- a/src/main/java/challenge/nDaysChallenge/domain/Stamp.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/Stamp.java
@@ -24,6 +24,8 @@ public class Stamp {
     public Room room;
     public String day;
     public LocalDate latestDate;
+    protected int usedPassCount;
+    protected int successCount;
 
 
     //==생성 메서드==//
@@ -32,6 +34,8 @@ public class Stamp {
         stamp.room = room;
         stamp.day = "";
         stamp.latestDate = LocalDate.now().minusDays(1L);
+        stamp.usedPassCount = 0;
+        stamp.successCount = 0;
         return stamp;
     }
 
@@ -40,29 +44,34 @@ public class Stamp {
     //스탬프 찍기
     public Stamp updateStamp(Room room, String day) {
 
-        if (!this.latestDate.isEqual(LocalDate.now())) {
             this.room = room;
             this.latestDate = LocalDate.now();
 
             if (this.day.equals("")) {  //첫 날
                 this.day = day;
             } else {
-                this.day += "," + day;
+                this.day += day;
             }
-        } else {
-            System.out.println("스탬프를 중복 요청했습니다.");
-        }
 
         return this;
     }
 
-    //마지막 스탬프
+    //마지막 스탬프 찾기
     public String getLatestStamp() {
 
-        if (this.day.length() > 1) {
-            String[] stampArr = this.day.split(",");
-            return stampArr[stampArr.length-1];
+        if (day.length() > 1) {
+            return day.substring(day.length()-1);
         }
-        return this.day;
+        return day;
+    }
+
+    //성공 +1
+    public void addSuccess() {
+        successCount += 1;
+    }
+
+    //실패 +1
+    public void addPass() {
+        usedPassCount += 1;
     }
 }

--- a/src/main/java/challenge/nDaysChallenge/domain/room/GroupRoom.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/room/GroupRoom.java
@@ -38,8 +38,6 @@ public class GroupRoom extends Room {
         this.status = RoomStatus.CONTINUE;
         this.passCount = passCount;
         this.reward = reward;
-        this.usedPassCount = usedPassCount;
-        this.successCount = successCount;
     }
 
 }

--- a/src/main/java/challenge/nDaysChallenge/domain/room/Room.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/room/Room.java
@@ -46,21 +46,9 @@ public class Room {
     protected Stamp stamp;
 
     protected int passCount;
-    protected int usedPassCount;
-    protected int successCount;
 
 
     //==비즈니스 로직==//
-    //성공 +1
-    public void addSuccess() {
-        successCount += 1;
-    }
-
-    //실패 +1
-    public void addPass() {
-        passCount += 1;
-        usedPassCount += 1;
-    }
 
     //챌린지 상태 변경
     public void end() {

--- a/src/main/java/challenge/nDaysChallenge/domain/room/SingleRoom.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/room/SingleRoom.java
@@ -53,8 +53,6 @@ public class SingleRoom extends Room {
         this.status = RoomStatus.CONTINUE;
         this.passCount = passCount;
         this.reward = reward;
-        this.usedPassCount = usedPassCount;
-        this.successCount = successCount;
     }
 
 }

--- a/src/main/java/challenge/nDaysChallenge/dto/request/Room/GroupRoomRequestDto.java
+++ b/src/main/java/challenge/nDaysChallenge/dto/request/Room/GroupRoomRequestDto.java
@@ -14,15 +14,15 @@ import java.util.Set;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupRoomRequestDto {
 
+    private String type;
     private String name;
     private String category;
-    private String reward;
-    private int passCount;
-
+    private Long totalDays;
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate startDate;
-    private Long totalDays;
-    private String type;
+    private int passCount;
+    private String reward;
+
     private int successCount;
     private int usedPassCount;
 
@@ -30,13 +30,13 @@ public class GroupRoomRequestDto {
 
     @Builder
     public GroupRoomRequestDto(String name, String category, String reward, int passCount, LocalDate startDate, Long totalDays, String type, int successCount, int usedPassCount, Set<Long> groupMembers) {
+        this.type = type;
         this.name = name;
         this.category = category;
-        this.reward = reward;
-        this.passCount = passCount;
-        this.startDate = startDate;
         this.totalDays = totalDays;
-        this.type = type;
+        this.startDate = startDate;
+        this.passCount = passCount;
+        this.reward = reward;
         this.successCount = successCount;
         this.usedPassCount = usedPassCount;
         for (Long members : groupMembers) {

--- a/src/main/java/challenge/nDaysChallenge/dto/request/Room/RoomRequestDto.java
+++ b/src/main/java/challenge/nDaysChallenge/dto/request/Room/RoomRequestDto.java
@@ -2,6 +2,7 @@ package challenge.nDaysChallenge.dto.request.Room;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
@@ -9,28 +10,28 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RoomRequestDto {
 
+    private String type;
     private String name;
     private String category;
-    private String reward;
-    private int passCount;
-
-    @JsonFormat(pattern = "yyyy-MM-dd")
-    private LocalDate startDate;
     private Long totalDays;
-    private String type;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+    private int passCount;
+    private String reward;
+
     private int successCount;
     private int usedPassCount;
 
 
     @Builder
     public RoomRequestDto(String name, String category, String reward, int passCount, LocalDate startDate, Long totalDays, String type, int successCount, int usedPassCount) {
+        this.type = type;
         this.name = name;
         this.category = category;
-        this.reward = reward;
-        this.passCount = passCount;
-        this.startDate = startDate;
         this.totalDays = totalDays;
-        this.type = type;
+        this.startDate = startDate;
+        this.passCount = passCount;
+        this.reward = reward;
         this.successCount = successCount;
         this.usedPassCount = usedPassCount;
     }

--- a/src/main/java/challenge/nDaysChallenge/dto/request/StampDto.java
+++ b/src/main/java/challenge/nDaysChallenge/dto/request/StampDto.java
@@ -1,17 +1,24 @@
 package challenge.nDaysChallenge.dto.request;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class StampDto {
 
     public Long roomNumber;
     public Long stampNumber;
     public String day;
 
+    public int successCount;
+    public int usedPassCount;
+
+    @Builder
+    public StampDto(Long roomNumber, Long stampNumber, String day, int successCount, int usedPassCount) {
+        this.roomNumber = roomNumber;
+        this.stampNumber = stampNumber;
+        this.day = day;
+        this.successCount = successCount;
+        this.usedPassCount = usedPassCount;
+    }
 }

--- a/src/main/java/challenge/nDaysChallenge/dto/response/Room/GroupRoomResponseDto.java
+++ b/src/main/java/challenge/nDaysChallenge/dto/response/Room/GroupRoomResponseDto.java
@@ -15,18 +15,18 @@ import java.util.Set;
 public class GroupRoomResponseDto {
 
     private Long roomNumber;
+    private String type;
     private String name;
     private String category;
-    private String reward;
-    private int passCount;
-    private String type;
-    private String status;
-
+    private Long totalDays;
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate startDate;
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate;
-    private Long totalDays;
+    private int passCount;
+    private String reward;
+    private String status;
+
 
     private Set<Long> groupMembers = new HashSet<>();
     private JSONObject jsonObject;
@@ -34,15 +34,15 @@ public class GroupRoomResponseDto {
     @Builder
     public GroupRoomResponseDto(Long roomNumber, String name, String category, String reward, int passCount, String type, String status, LocalDate startDate, LocalDate endDate, Long totalDays, Set<Long> groupMembers, Map<String, Long> memberStamps) {
         this.roomNumber = roomNumber;
+        this.type = type;
         this.name = name;
         this.category = category;
-        this.reward = reward;
-        this.type = type;
-        this.status = status;
-        this.passCount = passCount;
         this.totalDays = totalDays;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.passCount = passCount;
+        this.reward = reward;
+        this.status = status;
         for (Long members : groupMembers) {
             this.groupMembers.add(members);
         }

--- a/src/main/java/challenge/nDaysChallenge/dto/response/Room/RoomResponseDto.java
+++ b/src/main/java/challenge/nDaysChallenge/dto/response/Room/RoomResponseDto.java
@@ -11,35 +11,35 @@ import java.time.LocalDate;
 public class RoomResponseDto {
 
     private Long roomNumber;
+    private String type;
     private String name;
     private String category;
-    private String reward;
-    private int passCount;
-    private String type;
-    private String status;
-
+    private Long totalDays;
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate startDate;
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate;
+    private int passCount;
+    private String reward;
+    private String status;
+
     private Long stamp;
-    private Long totalDays;
     private int successCount;
     private int usedPassCount;
 
     @Builder
     public RoomResponseDto(Long roomNumber, String name, String category, String reward, int passCount, String type, String status, LocalDate startDate, LocalDate endDate, Long stamp, Long totalDays, int successCount, int usedPassCount) {
         this.roomNumber = roomNumber;
+        this.type = type;
         this.name = name;
         this.category = category;
-        this.reward = reward;
-        this.type = type;
-        this.status = status;
-        this.passCount = passCount;
-        this.stamp = stamp;
         this.totalDays = totalDays;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.passCount = passCount;
+        this.reward = reward;
+        this.status = status;
+        this.stamp = stamp;
         this.successCount = successCount;
         this.usedPassCount = usedPassCount;
     }

--- a/src/main/java/challenge/nDaysChallenge/repository/StampRepository.java
+++ b/src/main/java/challenge/nDaysChallenge/repository/StampRepository.java
@@ -13,4 +13,8 @@ public interface StampRepository extends JpaRepository<Stamp, Long> {
     @Query("select s from Stamp s where s.room = :room")
     public Stamp findByRoom(@Param("room") Room room);
 
+/*    @Query(value = "select * from group_room_stamps where room_number = :room and stamps_key = :key", nativeQuery = true)
+    public Object findByRoomAndMember(@Param(value = "room") Long roomNumber,
+                                      @Param(value = "key") String key);*/
+
 }

--- a/src/test/java/challenge/nDaysChallenge/Room/RoomServiceTest.java
+++ b/src/test/java/challenge/nDaysChallenge/Room/RoomServiceTest.java
@@ -244,7 +244,7 @@ public class RoomServiceTest {
 
         //then
         System.out.println("updateStamp.getDay() = " + updateStamp.getDay());
-        assertThat(updateStamp.getDay()).isEqualTo("o");
+        assertThat(updateStamp.getDay()).isEqualTo("ox");
     }
 
     @Test
@@ -262,18 +262,31 @@ public class RoomServiceTest {
     }
 
     @Test
+    public void findByRoomAndMember_쿼리() throws Exception {
+        //given
+        stampRepository.findByRoomAndMember(18L, "슬기");
+
+        //when
+
+        //then
+    }
+
+    @Test
     public void 스탬프_카운트_업데이트 () throws Exception {
         //given
         memberRepository.save(member);
         SingleRoom room = roomService.singleRoom(member, "기상", period, Category.ROUTINE, 2, "", 0, 0);
 
         //when
-        roomService.updateStamp(member, room.getNumber(), new StampDto(room.getNumber(), room.getStamp().getNumber(), "o,o,x,o"));
+        roomService.updateStamp(member, room.getNumber(), new StampDto(room.getNumber(), room.getStamp().getNumber(), "o", room.getStamp().getSuccessCount(), room.getPassCount()));
+        roomService.updateStamp(member, room.getNumber(), new StampDto(room.getNumber(), room.getStamp().getNumber(), "o", room.getStamp().getSuccessCount(), room.getPassCount()));
+        roomService.updateStamp(member, room.getNumber(), new StampDto(room.getNumber(), room.getStamp().getNumber(), "x", room.getStamp().getSuccessCount(), room.getPassCount()));
 
         em.flush();
         em.clear();
         //then
-        assertThat(room.getSuccessCount()).isEqualTo(1);
+        assertThat(room.getStamp().getSuccessCount()).isEqualTo(2);
+        assertThat(room.getStamp().getDay()).isEqualTo("oox");
     }
 
     //멤버


### PR DESCRIPTION
- dto 필드 챌린지 생성시 넣는 값 순서에 맞춰 변경
- ,로 구분하던 day 필드를 구분 없는 string으로 변경
- successCount와 usedPassCount를 Room에서 Stamp로 이동(그룹 챌린지 반영 시 다대다 이슈)

- 챌린지 상세 api 보낼 때 그룹챌린지에는 room에 stamp_number 없기 때문에 쿼리 짜서 수정해야 함