### PR TITLE
eb status 심각 오류 해결 중

### DIFF
--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -24,7 +24,7 @@ http {
   }
 
   upstream springboot {
-    server 127.0.0.1:8080;
+    server 127.0.0.1:5000;
     keepalive 1024;
   }
 


### PR DESCRIPTION
- bad substitution 해결(escape 문자 사용) 후 eb status 심각 오류 지속 됨
  - 5000 or 8443 포트 / corretto, 자바 버전 / 아마존 리눅스2 오류 등으로 원인 추측해 해결 중