### PR TITLE
다짐 도메인 변경 (응답DTO 중심)

### DIFF
--- a/src/main/java/challenge/nDaysChallenge/controller/dajim/DajimController.java
+++ b/src/main/java/challenge/nDaysChallenge/controller/dajim/DajimController.java
@@ -9,11 +9,13 @@ import challenge.nDaysChallenge.dto.response.dajim.DajimResponseDto;
 import challenge.nDaysChallenge.service.dajim.DajimService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @RestController
@@ -58,9 +60,14 @@ public class DajimController {
 
     //피드 전체 조회 (다짐 + 감정스티커 리스트)
     @GetMapping("/feed")
-    public ResponseEntity<?> viewDajimOnFeed(Principal principal){
+    public ResponseEntity<?> viewDajimOnFeed(@AuthenticationPrincipal @Nullable MemberAdapter memberAdapter){
+        List<DajimFeedResponseDto> dajimFeedDto;
 
-        List<DajimFeedResponseDto> dajimFeedDto = dajimService.viewDajimOnFeed(principal);
+        try {
+            dajimFeedDto = dajimService.viewDajimOnFeed(memberAdapter.getMember());
+        } catch (NullPointerException e) {
+            dajimFeedDto = dajimService.viewDajimOnFeed();
+        }
 
         return ResponseEntity.ok().body(dajimFeedDto);
 

--- a/src/main/java/challenge/nDaysChallenge/domain/member/MemberAdapter.java
+++ b/src/main/java/challenge/nDaysChallenge/domain/member/MemberAdapter.java
@@ -4,7 +4,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import java.util.*;
 
-public class MemberAdapter extends User implements UserDetails {
+public class MemberAdapter extends User {
 
     private Member member;
 

--- a/src/main/java/challenge/nDaysChallenge/dto/response/dajim/DajimFeedResponseDto.java
+++ b/src/main/java/challenge/nDaysChallenge/dto/response/dajim/DajimFeedResponseDto.java
@@ -1,11 +1,16 @@
 package challenge.nDaysChallenge.dto.response.dajim;
 
 import challenge.nDaysChallenge.domain.dajim.Dajim;
+import challenge.nDaysChallenge.domain.dajim.Sticker;
+import challenge.nDaysChallenge.domain.member.Member;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
+import org.springframework.lang.Nullable;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Getter
@@ -21,31 +26,57 @@ public class DajimFeedResponseDto {
 
     private String content;
 
-    private List<String> stickersList;
+    //다짐별 모든 스티커
+    private Map<String,Long> allStickers;
+
+    //로그인 사용자의 다짐별 스티커
+    @Nullable
+    private String loginSticker;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedDate;
 
-    public DajimFeedResponseDto(long dajimNumber, String nickname, int image, String content, List<String> stickersList, LocalDateTime updatedDate) {
+    public DajimFeedResponseDto(long dajimNumber, String nickname, int image, String content, Map<String,Long> allStickers, String loginSticker, LocalDateTime updatedDate) {
         this.dajimNumber = dajimNumber;
         this.nickname = nickname;
         this.image = image;
         this.content = content;
-        this.stickersList = stickersList;
+        this.allStickers = allStickers;
+        this.loginSticker = loginSticker;
         this.updatedDate = updatedDate;
     }
 
-    public static DajimFeedResponseDto of(Dajim dajim){
-        return new DajimFeedResponseDto(
-                dajim.getNumber(),
-                dajim.getMember().getNickname(),
-                dajim.getMember().getImage(),
-                dajim.getContent(),
-                dajim.getEmotions().stream().map(emotion ->
-                                emotion.getSticker().toString())
-                        .collect(Collectors.toList()),
-                dajim.getUpdatedDate()
-                );
+    public static DajimFeedResponseDto of(Dajim dajim, @Nullable Member member){
+
+        try {
+            return new DajimFeedResponseDto(
+                    dajim.getNumber(),
+                    dajim.getMember().getNickname(),
+                    dajim.getMember().getImage(),
+                    dajim.getContent(),
+                    dajim.getEmotions().stream()
+                            .map(emotion -> emotion.getSticker().toString())
+                            .collect(Collectors.groupingBy(s -> s, Collectors.counting())),
+                    dajim.getEmotions().stream()
+                            .filter(emotion -> emotion.getMember().getId().equals(member.getId()))
+                            .map(emotion -> emotion.getSticker().toString())
+                            .collect(Collectors.joining()),
+                    dajim.getUpdatedDate()
+            );
+        } catch (NullPointerException e){
+            return new DajimFeedResponseDto(
+                    dajim.getNumber(),
+                    dajim.getMember().getNickname(),
+                    dajim.getMember().getImage(),
+                    dajim.getContent(),
+                    dajim.getEmotions().stream()
+                            .map(emotion -> emotion.getSticker().toString())
+                            .collect(Collectors.groupingBy(s -> s, Collectors.counting())),
+                    "non-login",
+                    dajim.getUpdatedDate()
+            );
+        }
+
     }
 
 }

--- a/src/main/java/challenge/nDaysChallenge/repository/dajim/DajimRepository.java
+++ b/src/main/java/challenge/nDaysChallenge/repository/dajim/DajimRepository.java
@@ -31,7 +31,7 @@ public interface DajimRepository extends JpaRepository<Dajim, Long> {
     Optional<List<Dajim>> findAllByRoomNumber(@Param("roomNumber") Long roomNumber);
 
     //피드 다짐 조회 - open=PUBLIC인 다짐
-    @Query("SELECT d FROM Dajim d WHERE d.open = 'PUBLIC' ORDER BY d.number DESC")
-    List<Dajim> findAllByOpen();
+    @Query("SELECT d FROM Dajim d WHERE d.open = 'PUBLIC' ORDER BY d.updatedDate DESC")
+    Optional<List<Dajim>> findAllByOpen();
 
 }

--- a/src/main/java/challenge/nDaysChallenge/service/dajim/DajimService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/dajim/DajimService.java
@@ -4,6 +4,7 @@ import challenge.nDaysChallenge.domain.dajim.Dajim;
 import challenge.nDaysChallenge.domain.dajim.Emotion;
 import challenge.nDaysChallenge.domain.dajim.Open;
 import challenge.nDaysChallenge.domain.dajim.Sticker;
+import challenge.nDaysChallenge.domain.member.MemberAdapter;
 import challenge.nDaysChallenge.domain.room.Room;
 import challenge.nDaysChallenge.dto.request.dajim.DajimUpdateRequestDto;
 import challenge.nDaysChallenge.dto.request.dajim.DajimUploadRequestDto;
@@ -14,19 +15,23 @@ import challenge.nDaysChallenge.repository.dajim.DajimRepository;
 import challenge.nDaysChallenge.repository.dajim.EmotionRepository;
 import challenge.nDaysChallenge.repository.room.RoomRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.Principal;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.*;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class DajimService {
 
     private final DajimRepository dajimRepository;
@@ -78,30 +83,29 @@ public class DajimService {
         return dajimsList;
     }
 
-    //전체 다짐 조회 (피드)
+    //피드 - 전체 다짐 조회 (미로그인)
     @Transactional(readOnly = true)
-    public List<DajimFeedResponseDto> viewDajimOnFeed(Principal principal) {
-        List<Dajim> dajims = dajimRepository.findAllByOpen();
-
-        //피드 각 다짐별 스티커 총 개수 카운트
-        //다짐1: CHEER:1, SURPRISE:2,...
-        List<List<Sticker>> stickersList = dajims.stream().map(
-                dajim -> dajim.getEmotions().stream().map(
-                        emotion -> emotion.getSticker()).collect(Collectors.toList()
-                )
-        ).collect(Collectors.toList());
-        System.out.println(stickersList);
-
-        //사용자별 이모션 (멤버 닉네임, 다짐번호, 스티커내용)
-        if (principal!=null){
-            String id = principal.getName();
-            List<Emotion> memberEmotions = emotionRepository.findAllByMemberId(id)
-                    .orElseGet(ArrayList::new);
-        }
+    public List<DajimFeedResponseDto> viewDajimOnFeed() {
+        List<Dajim> dajims = dajimRepository.findAllByOpen()
+                .orElseGet(ArrayList::new);
 
         //도메인->dto
         List<DajimFeedResponseDto> dajimFeedList = dajims.stream().map(dajim ->
-                DajimFeedResponseDto.of(dajim)
+                DajimFeedResponseDto.of(dajim, null)
+        ).collect(Collectors.toList());
+
+        return dajimFeedList;
+    }
+
+    //피드 - 전체 다짐 조회 (로그인 시)
+    @Transactional(readOnly = true)
+    public List<DajimFeedResponseDto> viewDajimOnFeed(Member member) {
+        List<Dajim> dajims = dajimRepository.findAllByOpen()
+                .orElseGet(ArrayList::new);
+
+        //도메인->dto
+        List<DajimFeedResponseDto> dajimFeedList = dajims.stream().map(dajim ->
+                DajimFeedResponseDto.of(dajim, member)
         ).collect(Collectors.toList());
 
         return dajimFeedList;

--- a/src/test/java/challenge/nDaysChallenge/auth/AuthTest.http
+++ b/src/test/java/challenge/nDaysChallenge/auth/AuthTest.http
@@ -1,11 +1,11 @@
 ###회원가입
-POST http://ec2-34-214-168-51.us-west-2.compute.amazonaws.com/auth/signup
+POST http://localhost:8080/auth/signup
 Content-Type: application/json
 
 {
-  "id": "id12@gmail.com",
+  "id": "id123@gmail.com",
   "pw": "123",
-  "nickname": "abcd",
+  "nickname": "abd",
   "image": 3
 }
 
@@ -15,7 +15,7 @@ POST http://localhost:8080/auth/login
 Content-Type: application/json
 
 {
-  "id": "id12@gmail.com",
+  "id": "id123@gmail.com",
   "pw": "123"
 }
 

--- a/src/test/java/challenge/nDaysChallenge/dajim/DajimRepositoryTest.java
+++ b/src/test/java/challenge/nDaysChallenge/dajim/DajimRepositoryTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -105,7 +106,8 @@ class DajimRepositoryTest {
 
     @Test
     void 다짐_피드_조회(){
-        List<Dajim> dajimFeed = dajimRepository.findAllByOpen();
+        List<Dajim> dajimFeed = dajimRepository.findAllByOpen()
+                .orElseGet(ArrayList::new);
 
         assertThat(dajimFeed.size()).isEqualTo(2);
     }

--- a/src/test/java/challenge/nDaysChallenge/emotion/EmotionTest.http
+++ b/src/test/java/challenge/nDaysChallenge/emotion/EmotionTest.http
@@ -1,17 +1,17 @@
 ### 감정스티커 등록
 POST http://localhost:8080/feed/emotion
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJpZDEyQGdtYWlsLmNvbSIsImF1dGgiOiJudWxsIiwiZXhwIjoxNjc1NzU4OTQ0fQ.tsqapfdXPfAyvYMN7EV5tf3ClqFl7v4tR29aHk722VM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJpZDEyM0BnbWFpbC5jb20iLCJhdXRoIjoibnVsbCIsImV4cCI6MTY3NjA0NDI0Nn0.-z308xEvZzSgb-DZXVz8_xrKGYwvkhWVKZj0PBWYdFI
 
 {
-  "dajimNumber": 8,
-  "sticker": "LIKE"
+  "dajimNumber": 7,
+  "sticker": "WATCH"
 }
 
 ### 감정스티커 수정
 PATCH http://localhost:8080/feed/emotion
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYWVlODE5QGdtYWlsLmNvbSIsImF1dGgiOiJudWxsIiwiZXhwIjoxNjc1MzA5MTUxfQ.ZSUUNhyHOyRpgof43TClkZBgxBWiCiAJkvPuGGZOnLs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJpZDEyM0BnbWFpbC5jb20iLCJhdXRoIjoibnVsbCIsImV4cCI6MTY3NjA0NDI0Nn0.-z308xEvZzSgb-DZXVz8_xrKGYwvkhWVKZj0PBWYdFI
 
 {
   "dajimNumber": 1,


### PR DESCRIPTION
- 다짐피드 응답 DTO 에 필드 변경 및 추가
  - 전체 피드의 다짐별 스티커 필드 변경
    - 변수명 변경 (stickerList -> allStickers) 
    - Stream의 counting 연산 추가
      - List 타입의 스티커들 -> List<HashMap> 타입의 스티커별 개수로 데이터 수정
  -  로그인 사용자의 다짐별 스티커 필드 추가 (loginSticker)
      - 로그인 유저의 경우 해당 스티커 String으로 전송 ex. "LIKE"
      - 미로그인 유저일 경우 "non-login"으로 전송