### PR TITLE
다짐피드 응답데이터 추가

### DIFF
--- a/src/main/java/challenge/nDaysChallenge/dto/response/dajim/DajimFeedResponseDto.java
+++ b/src/main/java/challenge/nDaysChallenge/dto/response/dajim/DajimFeedResponseDto.java
@@ -72,7 +72,7 @@ public class DajimFeedResponseDto {
                     dajim.getEmotions().stream()
                             .map(emotion -> emotion.getSticker().toString())
                             .collect(Collectors.groupingBy(s -> s, Collectors.counting())),
-                    "non-login",
+                    "",
                     dajim.getUpdatedDate()
             );
         }

--- a/src/main/java/challenge/nDaysChallenge/repository/dajim/DajimRepository.java
+++ b/src/main/java/challenge/nDaysChallenge/repository/dajim/DajimRepository.java
@@ -35,10 +35,6 @@ public interface DajimRepository extends JpaRepository<Dajim, Long> {
             " ORDER BY d.updatedDate")
     Optional<List<Dajim>> findAllByRoomNumber(@Param("roomNumber") Long roomNumber);
 
-//    피드 다짐 조회 - open=PUBLIC인 다짐
-//    @Query("SELECT d FROM Dajim d WHERE d.open = 'PUBLIC' ORDER BY d.updatedDate DESC")
-//    Optional<List<Dajim>> findAllByOpen();
-
     Slice<Dajim> findByOpen(Open open, Pageable pageable);
 
 }

--- a/src/main/java/challenge/nDaysChallenge/service/dajim/DajimService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/dajim/DajimService.java
@@ -89,38 +89,27 @@ public class DajimService {
 
     //피드 - 전체 다짐 조회 (미로그인)
     @Transactional(readOnly = true)
-    public Slice<DajimResponseDto> viewDajimFeedWithoutLogin(Pageable pageable) {
-//        List<Dajim> dajims = dajimRepository.findAllByOpen()
-//                .orElseGet(ArrayList::new);
-//
-//        //도메인->dto
-//        List<DajimFeedResponseDto> dajimFeedList = dajims.stream().map(dajim ->
-//                DajimFeedResponseDto.of(dajim, null)
-//        ).collect(Collectors.toList());
-        Slice<DajimResponseDto> dajimPage = dajimRepository.findByOpen(Open.PUBLIC, pageable)
-                                                            .map(DajimResponseDto::of);
+    public Slice<DajimFeedResponseDto> viewDajimFeedWithoutLogin(Pageable pageable) {
+        Slice<Dajim> dajimPage = dajimRepository.findByOpen(Open.PUBLIC, pageable);
 
-        return new CustomSliceImpl<>(dajimPage.getContent(),pageable, dajimPage.hasNext());
+        List<DajimFeedResponseDto> dajimFeedList = dajimPage.getContent().stream()
+                .map(dajim -> DajimFeedResponseDto.of(dajim, null))
+                .collect(toList());
+
+        return new CustomSliceImpl<>(dajimFeedList, pageable, dajimPage.hasNext());
     }
 
     //피드 - 전체 다짐 조회 (로그인 시)
     @Transactional(readOnly = true)
-    public Slice<DajimResponseDto> viewDajimFeedLoggedIn(Member member, Pageable pageable) {
-//        List<Dajim> dajims = dajimRepository.findAllByOpen()
-//                .orElseGet(ArrayList::new);
-//
-//        //도메인->dto
-//        List<DajimFeedResponseDto> dajimFeedList = dajims.stream().map(dajim ->
-//                DajimFeedResponseDto.of(dajim, member)
-//        ).collect(Collectors.toList());
+    public Slice<DajimFeedResponseDto> viewDajimFeedLoggedIn(Member member, Pageable pageable) {
+        Slice<Dajim> dajimPage = dajimRepository.findByOpen(Open.PUBLIC, pageable);
 
-        Slice<DajimResponseDto> dajimPage = dajimRepository.findByOpen(Open.PUBLIC, pageable)
-                                                            .map(DajimResponseDto::of);
-
-        //allstickers, loginsticker 직접 추가 (slice.getcontent.add)
+        List<DajimFeedResponseDto> dajimFeedList = dajimPage.getContent().stream()
+                .map(dajim -> DajimFeedResponseDto.of(dajim, member))
+                .collect(toList());
 
 
-        return new CustomSliceImpl<>(dajimPage.getContent(),pageable, dajimPage.hasNext());
+        return new CustomSliceImpl<>(dajimFeedList,pageable, dajimPage.hasNext());
     }
 
     //다짐 수정 시 작성자/룸 체크

--- a/src/test/java/challenge/nDaysChallenge/dajim/DajimServiceTest.java
+++ b/src/test/java/challenge/nDaysChallenge/dajim/DajimServiceTest.java
@@ -180,14 +180,14 @@ public class DajimServiceTest {
 //        when(dajimRepository.findAllByOpen(Open.PUBLIC,Pageable.ofSize(10))).thenReturn();
 
         //when
-        Slice<DajimResponseDto> dajimPage = dajimService.viewDajimFeedWithoutLogin(Pageable.ofSize(0));
+        Slice<DajimFeedResponseDto> dajimFeedPage = dajimService.viewDajimFeedWithoutLogin(Pageable.ofSize(0));
 
         //then
-        System.out.println(dajimPage.getContent().stream().map(d->d.getContent()).collect(Collectors.toList()));
+        System.out.println(dajimFeedPage.getContent().stream().map(d->d.getContent()).collect(Collectors.toList()));
 //        System.out.println(dajims.getContent().stream().map(d->d.getAllStickers()).collect(Collectors.toList()));
 //        System.out.println(dajims.getContent().stream().map(d->d.getLoginSticker()).collect(Collectors.joining()));
 
-        assertThat(dajimPage.getContent().size()).isEqualTo(2);
+        assertThat(dajimFeedPage.getContent().size()).isEqualTo(2);
 //        assertThat(dajimFeedResponseDtos.stream().map(d->d.getLoginSticker()).collect(Collectors.toSet())).size().isEqualTo(1);
 
     }
@@ -201,14 +201,14 @@ public class DajimServiceTest {
 //        when(dajimRepository.findAllByOpen(Open.PUBLIC,Pageable.ofSize(10))).thenReturn();
 
         //when
-        Slice<DajimResponseDto> dajimPage = dajimService.viewDajimFeedLoggedIn(member, Pageable.ofSize(0));
+        Slice<DajimFeedResponseDto> dajimFeedPage = dajimService.viewDajimFeedLoggedIn(member, Pageable.ofSize(0));
 
         //then
-        System.out.println(dajimPage.getContent().stream().map(d->d.getContent()).collect(Collectors.toList()));
+        System.out.println(dajimFeedPage.getContent().stream().map(d->d.getContent()).collect(Collectors.toList()));
 //        System.out.println(dajimFeedResponseDtos.stream().map(d->d.getAllStickers()).collect(Collectors.toList()));
 //        System.out.println(dajimFeedResponseDtos.stream().map(d->d.getLoginSticker()).collect(Collectors.joining()));
 
-        assertThat(dajimPage.getContent().size()).isEqualTo(2);
+        assertThat(dajimFeedPage.getContent().size()).isEqualTo(2);
 //        assertThat(dajimFeedResponseDtos.stream().map(d->d.getLoginSticker()).collect(Collectors.toList())).isNotEmpty();
     }
 


### PR DESCRIPTION
- Slice 객체의 content에 Stream API 적용한 후, 필요한 응답 데이터 전달하는 커스텀 Slice 객체 리턴하도록 함