### PR TITLE
다짐 도메인 수정 등

### DIFF
--- a/src/main/java/challenge/nDaysChallenge/NDaysChallengeApplication.java
+++ b/src/main/java/challenge/nDaysChallenge/NDaysChallengeApplication.java
@@ -3,8 +3,10 @@ package challenge.nDaysChallenge;
 import org.hibernate.annotations.Source;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 
 @SpringBootApplication
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 public class NDaysChallengeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/challenge/nDaysChallenge/controller/dajim/DajimController.java
+++ b/src/main/java/challenge/nDaysChallenge/controller/dajim/DajimController.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.*;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -61,13 +62,11 @@ public class DajimController {
         return ResponseEntity.ok().body(dajimResponseDtoList);
     }
 
-    //피드 전체 조회 (다짐 + 감정스티커 리스트)
+    //피드 전체 조회 (다짐 + 감정스티커)
     @GetMapping("/feed")
     public ResponseEntity<?> viewDajimOnFeed(
             @AuthenticationPrincipal @Nullable MemberAdapter memberAdapter,
             @PageableDefault(sort = "updatedDate", direction = Sort.Direction.DESC) Pageable pageable){
-//        List<DajimFeedResponseDto> dajimFeedDto;
-
         Slice dajimPage;
 
         try {

--- a/src/main/java/challenge/nDaysChallenge/controller/dajim/DajimController.java
+++ b/src/main/java/challenge/nDaysChallenge/controller/dajim/DajimController.java
@@ -62,22 +62,6 @@ public class DajimController {
         return ResponseEntity.ok().body(dajimResponseDtoList);
     }
 
-    //피드 전체 조회 (다짐 + 감정스티커)
-    @GetMapping("/feed")
-    public ResponseEntity<?> viewDajimOnFeed(
-            @AuthenticationPrincipal @Nullable MemberAdapter memberAdapter,
-            @PageableDefault(sort = "updatedDate", direction = Sort.Direction.DESC) Pageable pageable){
-        Slice dajimPage;
-
-        try {
-            dajimPage = dajimService.viewDajimFeedLoggedIn(memberAdapter.getMember(), pageable);
-        } catch (NullPointerException e) {
-            dajimPage = dajimService.viewDajimFeedWithoutLogin(pageable);
-        }
-
-        return ResponseEntity.ok().body(dajimPage);
-
-    }
 
     private void checkLogin(Member member) {
         if (member == null) {

--- a/src/main/java/challenge/nDaysChallenge/controller/dajim/DajimFeedController.java
+++ b/src/main/java/challenge/nDaysChallenge/controller/dajim/DajimFeedController.java
@@ -1,0 +1,45 @@
+package challenge.nDaysChallenge.controller.dajim;
+
+import challenge.nDaysChallenge.domain.member.Member;
+import challenge.nDaysChallenge.domain.member.MemberAdapter;
+import challenge.nDaysChallenge.dto.request.dajim.DajimUpdateRequestDto;
+import challenge.nDaysChallenge.dto.request.dajim.DajimUploadRequestDto;
+import challenge.nDaysChallenge.dto.response.dajim.DajimResponseDto;
+import challenge.nDaysChallenge.service.dajim.DajimFeedService;
+import challenge.nDaysChallenge.service.dajim.DajimService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class DajimFeedController {
+
+    private final DajimFeedService dajimFeedService;
+
+    //피드 전체 조회 (다짐 + 감정스티커)
+    @GetMapping("/feed")
+    public ResponseEntity<?> viewDajimOnFeed(
+            @AuthenticationPrincipal @Nullable MemberAdapter memberAdapter,
+            @PageableDefault(sort = "updatedDate", direction = Sort.Direction.DESC) Pageable pageable){
+        Slice dajimPage;
+
+        try {
+            dajimPage = dajimFeedService.viewFeedLoggedIn(memberAdapter.getMember(), pageable);
+        } catch (NullPointerException e) {
+            dajimPage = dajimFeedService.viewFeedWithoutLogin(pageable);
+        }
+
+        return ResponseEntity.ok().body(dajimPage);
+
+    }
+
+}

--- a/src/main/java/challenge/nDaysChallenge/service/RelationshipService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/RelationshipService.java
@@ -13,6 +13,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,16 +31,34 @@ public class RelationshipService {
     private final RelationshipRepository relationshipRepository;
     private final MemberRepository memberRepository;
 
+    private final EntityManager em;
+
     //id, nickname 검색//
     public Member findFriends(String id, String nickname) {
-        if (nickname.length()>0&&id.equals("")||id==null) {
-            return memberRepository.findByNickname(nickname)
-                    .orElseThrow(() -> new RuntimeException("해당 닉네임의 사용자가 없습니다."));
-        } else if (id.length()>0&&nickname.equals("")||nickname==null) {
-            return memberRepository.findById(id)
-                    .orElseThrow(() -> new RuntimeException("해당 아이디의 사용자가 없습니다."));
+//        if (nickname!=null&&!nickname.isEmpty()) {
+//            return memberRepository.findByNickname(nickname)
+//                    .orElseThrow(() -> new RuntimeException("해당 닉네임의 사용자가 없습니다."));
+//        } else if (id!=null&&!id.isEmpty()) {
+//            return memberRepository.findById(id)
+//                    .orElseThrow(() -> new RuntimeException("해당 아이디의 사용자가 없습니다."));
+//        }
+//        throw new RuntimeException("친구 신청할 사용자의 닉네임이나 아이디를 입력해주세요.");
+        String jpql = "select m from Member m where ";
+
+        if (nickname!=null&&!nickname.isEmpty()) {
+            jpql += "m.nickname = :nickname";
+        } else if (id!=null&&!id.isEmpty()) {
+            jpql += "m.id = :id";
         }
-        return null;
+
+        TypedQuery<Member> query = em.createQuery(jpql, Member.class);
+        if (nickname!=null&&!nickname.isEmpty()) {
+            query = query.setParameter("nickname", nickname);
+        } else if (id!=null&&!id.isEmpty()) {
+            query = query.setParameter("id", id);
+        }
+
+        return query.getSingleResult();
     }
 
     //relationship 생성//

--- a/src/main/java/challenge/nDaysChallenge/service/dajim/DajimFeedService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/dajim/DajimFeedService.java
@@ -1,0 +1,62 @@
+package challenge.nDaysChallenge.service.dajim;
+
+import challenge.nDaysChallenge.domain.dajim.Dajim;
+import challenge.nDaysChallenge.domain.dajim.Open;
+import challenge.nDaysChallenge.domain.member.Member;
+import challenge.nDaysChallenge.domain.room.Room;
+import challenge.nDaysChallenge.dto.request.dajim.DajimUpdateRequestDto;
+import challenge.nDaysChallenge.dto.request.dajim.DajimUploadRequestDto;
+import challenge.nDaysChallenge.dto.response.dajim.DajimFeedResponseDto;
+import challenge.nDaysChallenge.dto.response.dajim.DajimResponseDto;
+import challenge.nDaysChallenge.repository.dajim.DajimRepository;
+import challenge.nDaysChallenge.repository.room.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class DajimFeedService {
+
+    private final DajimRepository dajimRepository;
+
+    //피드 - 전체 다짐 조회 (미로그인)
+    @PreAuthorize("isAnonymous()")
+    @Transactional(readOnly = true)
+    public Slice<DajimFeedResponseDto> viewFeedWithoutLogin(Pageable pageable) {
+        Slice<Dajim> dajimPage = dajimRepository.findByOpen(Open.PUBLIC, pageable);
+
+        List<DajimFeedResponseDto> dajimFeedList = dajimPage.getContent().stream()
+                .map(dajim -> DajimFeedResponseDto.of(dajim, null))
+                .collect(toList());
+
+        return new CustomSliceImpl<>(dajimFeedList, pageable, dajimPage.hasNext());
+    }
+
+    //피드 - 전체 다짐 조회 (로그인 시)
+    @PreAuthorize("isAuthenticated()")
+    @Transactional(readOnly = true)
+    public Slice<DajimFeedResponseDto> viewFeedLoggedIn(Member member, Pageable pageable) {
+        Slice<Dajim> dajimPage = dajimRepository.findByOpen(Open.PUBLIC, pageable);
+
+        List<DajimFeedResponseDto> dajimFeedList = dajimPage.getContent().stream()
+                .map(dajim -> DajimFeedResponseDto.of(dajim, member))
+                .collect(toList());
+
+
+        return new CustomSliceImpl<>(dajimFeedList,pageable, dajimPage.hasNext());
+    }
+
+}
+

--- a/src/main/java/challenge/nDaysChallenge/service/dajim/DajimService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/dajim/DajimService.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.lang.Nullable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,8 +42,6 @@ public class DajimService {
     private final DajimRepository dajimRepository;
 
     private final RoomRepository roomRepository;
-
-    private final EmotionRepository emotionRepository;
 
     //다짐 등록
     public DajimResponseDto uploadDajim(Long roomNumber, DajimUploadRequestDto dajimUploadRequestDto, Member member) {
@@ -88,6 +87,7 @@ public class DajimService {
     }
 
     //피드 - 전체 다짐 조회 (미로그인)
+    @PreAuthorize("isAnonymous()")
     @Transactional(readOnly = true)
     public Slice<DajimFeedResponseDto> viewDajimFeedWithoutLogin(Pageable pageable) {
         Slice<Dajim> dajimPage = dajimRepository.findByOpen(Open.PUBLIC, pageable);
@@ -100,6 +100,7 @@ public class DajimService {
     }
 
     //피드 - 전체 다짐 조회 (로그인 시)
+    @PreAuthorize("isAuthenticated()")
     @Transactional(readOnly = true)
     public Slice<DajimFeedResponseDto> viewDajimFeedLoggedIn(Member member, Pageable pageable) {
         Slice<Dajim> dajimPage = dajimRepository.findByOpen(Open.PUBLIC, pageable);

--- a/src/main/java/challenge/nDaysChallenge/service/dajim/DajimService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/dajim/DajimService.java
@@ -86,33 +86,6 @@ public class DajimService {
         return dajimsList;
     }
 
-    //피드 - 전체 다짐 조회 (미로그인)
-    @PreAuthorize("isAnonymous()")
-    @Transactional(readOnly = true)
-    public Slice<DajimFeedResponseDto> viewDajimFeedWithoutLogin(Pageable pageable) {
-        Slice<Dajim> dajimPage = dajimRepository.findByOpen(Open.PUBLIC, pageable);
-
-        List<DajimFeedResponseDto> dajimFeedList = dajimPage.getContent().stream()
-                .map(dajim -> DajimFeedResponseDto.of(dajim, null))
-                .collect(toList());
-
-        return new CustomSliceImpl<>(dajimFeedList, pageable, dajimPage.hasNext());
-    }
-
-    //피드 - 전체 다짐 조회 (로그인 시)
-    @PreAuthorize("isAuthenticated()")
-    @Transactional(readOnly = true)
-    public Slice<DajimFeedResponseDto> viewDajimFeedLoggedIn(Member member, Pageable pageable) {
-        Slice<Dajim> dajimPage = dajimRepository.findByOpen(Open.PUBLIC, pageable);
-
-        List<DajimFeedResponseDto> dajimFeedList = dajimPage.getContent().stream()
-                .map(dajim -> DajimFeedResponseDto.of(dajim, member))
-                .collect(toList());
-
-
-        return new CustomSliceImpl<>(dajimFeedList,pageable, dajimPage.hasNext());
-    }
-
     //다짐 수정 시 작성자/룸 체크
     private void checkRoomAndMember(Dajim dajim, Member member, Long roomNumber){
         if (dajim.getMember()!=member || dajim.getRoom().getNumber()!=roomNumber){

--- a/src/test/java/challenge/nDaysChallenge/dajim/DajimServiceTest.java
+++ b/src/test/java/challenge/nDaysChallenge/dajim/DajimServiceTest.java
@@ -20,6 +20,7 @@ import challenge.nDaysChallenge.repository.member.MemberRepository;
 import challenge.nDaysChallenge.repository.room.RoomRepository;
 import challenge.nDaysChallenge.repository.room.SingleRoomRepository;
 import challenge.nDaysChallenge.service.RoomService;
+import challenge.nDaysChallenge.service.dajim.DajimFeedService;
 import challenge.nDaysChallenge.service.dajim.DajimService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,9 @@ public class DajimServiceTest {
 
     @Mock
     private DajimRepository dajimRepository;
+
+    @Mock
+    private DajimFeedService dajimFeedService;
 
     @Mock
     private EmotionRepository emotionRepository;
@@ -180,7 +184,7 @@ public class DajimServiceTest {
 //        when(dajimRepository.findAllByOpen(Open.PUBLIC,Pageable.ofSize(10))).thenReturn();
 
         //when
-        Slice<DajimFeedResponseDto> dajimFeedPage = dajimService.viewDajimFeedWithoutLogin(Pageable.ofSize(0));
+        Slice<DajimFeedResponseDto> dajimFeedPage = dajimFeedService.viewFeedWithoutLogin(Pageable.ofSize(0));
 
         //then
         System.out.println(dajimFeedPage.getContent().stream().map(d->d.getContent()).collect(Collectors.toList()));
@@ -201,7 +205,7 @@ public class DajimServiceTest {
 //        when(dajimRepository.findAllByOpen(Open.PUBLIC,Pageable.ofSize(10))).thenReturn();
 
         //when
-        Slice<DajimFeedResponseDto> dajimFeedPage = dajimService.viewDajimFeedLoggedIn(member, Pageable.ofSize(0));
+        Slice<DajimFeedResponseDto> dajimFeedPage = dajimFeedService.viewFeedLoggedIn(member, Pageable.ofSize(0));
 
         //then
         System.out.println(dajimFeedPage.getContent().stream().map(d->d.getContent()).collect(Collectors.toList()));

--- a/src/test/java/challenge/nDaysChallenge/relationship/SearchTest.http
+++ b/src/test/java/challenge/nDaysChallenge/relationship/SearchTest.http
@@ -1,3 +1,3 @@
 GET http://localhost:8080/friends/find?id=&nickname=ab
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJpZDEyQGdtYWlsLmNvbSIsImF1dGgiOiJudWxsIiwiZXhwIjoxNjc1ODMzODI3fQ.z5iPB7C2LbKJLVxI_N5yfqR5h655xp5imNE7rMIzrwU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJpZDEyM0BnbWFpbC5jb20iLCJhdXRoIjoibnVsbCIsImV4cCI6MTY3Nzg1MjgzNX0.EivmwySsdWpbUTrpvWUwj7cdd_bZJVkiQwRxYgrwQBo


### PR DESCRIPTION
- 다짐, 다짐피드로 도메인 재분리
  - 챌린지 내 다짐 작성/수정/조회와 피드 내 다짐 조회로 구분되어 도메인 분리시킴
- 다짐피드 서비스 수정
  - 각 메소드에 PreAuthorize 어노테이션 설정해 로그인 여부에 따른 인가 로직 추가함
- 친구 도메인 친구 검색 메소드 수정
  - if 조건문 -> JPQL 동적 쿼리로 변경해 확장성 높임