### PR TITLE
다짐, 이모션 도메인 중복 코드 제거

### DIFF
--- a/src/main/java/challenge/nDaysChallenge/repository/dajim/DajimRepository.java
+++ b/src/main/java/challenge/nDaysChallenge/repository/dajim/DajimRepository.java
@@ -20,11 +20,9 @@ public interface DajimRepository extends JpaRepository<Dajim, Long> {
 
     Optional<Dajim> findByNumber(Long dajimNumber);
 
-    @Query("SELECT d FROM Dajim d WHERE d.member.id = :memberId AND d.room.number = :roomNumber")
-    Optional<Dajim> findByMemberIdAndRoomNumber(@Param("memberId") String memberId, @Param("roomNumber") Long roomNumber);
+    Optional<Dajim> findByMember_IdAndRoom_Number(String memberId, Long roomNumber);
 
-    @Query("SELECT d FROM Dajim d WHERE d.member.nickname = :nickname")
-    Optional<List<Dajim>> findAllByMemberNickname(@Param("nickname") String nickname);
+    Optional<List<Dajim>> findAllByMember_Nickname(String nickname);
 
     //챌린지 룸 다짐 조회 - 룸멤버 (1~4명) 다짐 상세 조회
     @Query("SELECT d FROM Dajim d JOIN d.room r" +

--- a/src/main/java/challenge/nDaysChallenge/repository/dajim/EmotionRepository.java
+++ b/src/main/java/challenge/nDaysChallenge/repository/dajim/EmotionRepository.java
@@ -13,9 +13,6 @@ import java.util.Optional;
 public interface EmotionRepository extends JpaRepository<Emotion, Long> {
 
     //수정/삭제할 이모션 불러오기
-    @Query("select e from Emotion e " +
-            "where e.dajim.number = :dajimNumber " +
-            "and e.member.number = :memberNumber")
-    Optional<Emotion> findByDajimAndMember(@Param("dajimNumber")Long dajimNumber, @Param("memberNumber")Long memberNumber);
+    Optional<Emotion> findByDajim_NumberAndMember_Number(Long dajimNumber, Long memberNumber);
 
 }

--- a/src/main/java/challenge/nDaysChallenge/service/dajim/DajimService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/dajim/DajimService.java
@@ -66,10 +66,8 @@ public class DajimService {
 
     //다짐 수정
     public DajimResponseDto updateDajim(Long roomNumber, DajimUpdateRequestDto dajimUpdateRequestDto, String id) {
-        Dajim dajim = dajimRepository.findByMember_IdAndRoom_Number(id, roomNumber)
-                .orElseThrow(()->new RuntimeException("다짐을 찾을 수 없습니다."));
-
-        checkRoomAndMember(dajim, id, roomNumber); //다짐이 소속된 룸에서 실행 중인지, 작성한 다짐을 수정하는지 확인
+        Dajim dajim = dajimRepository.findByMember_IdAndRoom_Number(id, roomNumber) //다짐이 소속된 룸에서 실행 중인지, 작성한 다짐을 수정하는지 확인
+                .orElseThrow(()->new RuntimeException("해당 멤버 아이디와 룸 넘버를 가진 다짐을 찾을 수 없습니다."));
 
         Dajim updatedDajim = dajim.update(Open.valueOf(dajimUpdateRequestDto.getOpen()), dajimUpdateRequestDto.getContent());
 
@@ -90,13 +88,6 @@ public class DajimService {
         return dajims.stream()
                 .map(dajim -> DajimResponseDto.of(dajim))
                 .collect(Collectors.toList());
-    }
-
-    //다짐 수정 시 작성자/룸 체크
-    private void checkRoomAndMember(Dajim dajim, String id, Long roomNumber){
-        if (!dajim.getMember().getId().equals(id) || !dajim.getRoom().getNumber().equals(roomNumber)){
-            throw new RuntimeException("해당 챌린지 룸에 대한 접근 권한이 없습니다.");
-        }
     }
 
 }

--- a/src/main/java/challenge/nDaysChallenge/service/dajim/DajimService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/dajim/DajimService.java
@@ -52,7 +52,7 @@ public class DajimService {
                 .orElseThrow(() -> new RuntimeException("해당 id의 사용자를 찾아오는 데 실패했습니다."));
 
         //다짐 존재 여부 확인 (같은 룸-멤버에선 하나의 다짐만 허용)
-        if (dajimRepository.findByMemberIdAndRoomNumber(id, roomNumber).isPresent()){
+        if (dajimRepository.findByMember_IdAndRoom_Number(id, roomNumber).isPresent()){
             throw new RuntimeException("이미 존재하는 다짐입니다.");
         }
 
@@ -66,7 +66,7 @@ public class DajimService {
 
     //다짐 수정
     public DajimResponseDto updateDajim(Long roomNumber, DajimUpdateRequestDto dajimUpdateRequestDto, String id) {
-        Dajim dajim = dajimRepository.findByMemberIdAndRoomNumber(id, roomNumber)
+        Dajim dajim = dajimRepository.findByMember_IdAndRoom_Number(id, roomNumber)
                 .orElseThrow(()->new RuntimeException("다짐을 찾을 수 없습니다."));
 
         checkRoomAndMember(dajim, id, roomNumber); //다짐이 소속된 룸에서 실행 중인지, 작성한 다짐을 수정하는지 확인
@@ -94,7 +94,7 @@ public class DajimService {
 
     //다짐 수정 시 작성자/룸 체크
     private void checkRoomAndMember(Dajim dajim, String id, Long roomNumber){
-        if (dajim.getMember().getId()!=id || dajim.getRoom().getNumber()!=roomNumber){
+        if (!dajim.getMember().getId().equals(id) || !dajim.getRoom().getNumber().equals(roomNumber)){
             throw new RuntimeException("해당 챌린지 룸에 대한 접근 권한이 없습니다.");
         }
     }

--- a/src/main/java/challenge/nDaysChallenge/service/dajim/EmotionService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/dajim/EmotionService.java
@@ -33,7 +33,7 @@ public class EmotionService {
                 .orElseThrow(() -> new RuntimeException("해당 id의 사용자를 찾아오는 데 실패했습니다."));
 
         //이미 존재하는 이모션인지 확인 (한 다짐, 한 멤버 당 하나의 이모션)
-        if (emotionRepository.findByDajimAndMember(emotionRequestDto.getDajimNumber(), member.getNumber()).isPresent()){
+        if (emotionRepository.findByDajim_NumberAndMember_Number(emotionRequestDto.getDajimNumber(), member.getNumber()).isPresent()){
             throw new RuntimeException("이미 존재하는 이모션입니다.");
         }
 
@@ -59,7 +59,7 @@ public class EmotionService {
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("해당 id의 사용자를 찾아오는 데 실패했습니다."));
 
-        Emotion emotion = emotionRepository.findByDajimAndMember(emotionRequestDto.getDajimNumber(), member.getNumber())
+        Emotion emotion = emotionRepository.findByDajim_NumberAndMember_Number(emotionRequestDto.getDajimNumber(), member.getNumber())
                 .orElseThrow(()->new RuntimeException("수정할 이모션을 찾을 수 없습니다."));
 
         emotion.update(Sticker.valueOf(emotionRequestDto.getSticker())); //수정 반영
@@ -71,7 +71,7 @@ public class EmotionService {
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("해당 id의 사용자를 찾아오는 데 실패했습니다."));
 
-        Emotion emotion = emotionRepository.findByDajimAndMember(emotionRequestDto.getDajimNumber(), member.getNumber())
+        Emotion emotion = emotionRepository.findByDajim_NumberAndMember_Number(emotionRequestDto.getDajimNumber(), member.getNumber())
                 .orElseThrow(()->new RuntimeException("수정할 이모션을 찾을 수 없습니다."));
 
         emotionRepository.delete(emotion);

--- a/src/main/java/challenge/nDaysChallenge/service/member/MemberService.java
+++ b/src/main/java/challenge/nDaysChallenge/service/member/MemberService.java
@@ -119,7 +119,7 @@ public class MemberService {
     @Transactional
     public void deleteRelatedEntities(Member member){
         //참조 엔티티들 불러오기
-        List<Dajim> dajims = dajimRepository.findAllByMemberNickname(member.getNickname()).orElseGet(ArrayList::new);
+        List<Dajim> dajims = dajimRepository.findAllByMember_Nickname(member.getNickname()).orElseGet(ArrayList::new);
         List<RoomMember> roomMembers = roomMemberRepository.findAllByMemberNickname(member.getNickname()).orElseGet(ArrayList::new);
         List<Stamp> stamps = Stream
                 .concat(singleRoomRepository.findStampByMember(member.getId()).stream(), roomMemberRepository.findStampByMember(member).stream())

--- a/src/test/java/challenge/nDaysChallenge/Room/awsRoomTest.http
+++ b/src/test/java/challenge/nDaysChallenge/Room/awsRoomTest.http
@@ -9,7 +9,7 @@ Content-Type: application/json
 ### 개인 챌린지 생성
 POST http://localhost:8080/challenge
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJpZDEyM0BnbWFpbC5jb20iLCJhdXRoIjoiUk9MRV9VU0VSIiwiZXhwIjoxNjgyNjYzODI1fQ.b5CwSseC6pa9IKi0yWu5siljRFAyJefE4I2QPQmerTs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJpZDEyMzEyQGdtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2ODY5ODQ1NDR9.ZqnpCp1ENHT2obfkRPvqbuddft9wtNG4cli5QkzkPjE
 
 {
   "name": "명상",

--- a/src/test/java/challenge/nDaysChallenge/auth/AuthTest.http
+++ b/src/test/java/challenge/nDaysChallenge/auth/AuthTest.http
@@ -3,9 +3,9 @@ POST http://localhost:8080/auth/signup
 Content-Type: application/json
 
 {
-  "id": "id12312@gmail.com",
+  "id": "id1234567@gmail.com",
   "pw": "Aa!!dd2df",
-  "nickname": "닉네ame",
+  "nickname": "test",
   "image": 2
 }
 

--- a/src/test/java/challenge/nDaysChallenge/auth/AuthTest.http
+++ b/src/test/java/challenge/nDaysChallenge/auth/AuthTest.http
@@ -3,9 +3,9 @@ POST http://localhost:8080/auth/signup
 Content-Type: application/json
 
 {
-  "id": "id1231@gmail.com",
-  "pw": "Aa!!dd2d",
-  "nickname": "닉네im",
+  "id": "id12312@gmail.com",
+  "pw": "Aa!!dd2df",
+  "nickname": "닉네ame",
   "image": 2
 }
 
@@ -15,8 +15,8 @@ POST {{review-api}}/auth/login
 Content-Type: application/json
 
 {
-  "id": "id123@gmail.com",
-  "pw": "123"
+  "id": "id12312@gmail.com",
+  "pw": "Aa!!dd2df"
 }
 
 ###로그아웃

--- a/src/test/java/challenge/nDaysChallenge/dajim/DajimRepositoryTest.java
+++ b/src/test/java/challenge/nDaysChallenge/dajim/DajimRepositoryTest.java
@@ -86,11 +86,10 @@ class DajimRepositoryTest {
 
     @Test
     void 다짐번호로_다짐_조회(){
-        Dajim dajim1 = dajimRepository.findByMemberIdAndRoomNumber(savedDajim1.getMember().getId(),savedDajim1.getRoom().getNumber())
+        Dajim dajim1 = dajimRepository.findByMember_IdAndRoom_Number(savedDajim1.getMember().getId(),savedDajim1.getRoom().getNumber())
                 .orElseThrow(()->new RuntimeException("다짐이 없습니다"));
-        Dajim dajim2 = dajimRepository.findByMemberIdAndRoomNumber(savedDajim2.getMember().getId(),savedDajim2.getRoom().getNumber())
+        Dajim dajim2 = dajimRepository.findByMember_IdAndRoom_Number(savedDajim2.getMember().getId(),savedDajim2.getRoom().getNumber())
                 .orElseThrow(()->new RuntimeException("다짐이 없습니다"));
-
 
         assertThat(dajim1.getMember().getNumber()).isEqualTo(savedDajim1.getMember().getNumber());
         assertThat(dajim2.getMember().getNumber()).isEqualTo(savedDajim2.getMember().getNumber());
@@ -98,7 +97,7 @@ class DajimRepositoryTest {
 
     @Test
     void 특정_멤버의_다짐_전체_조회(){
-        List<Dajim> nickDajims = dajimRepository.findAllByMemberNickname("nick2")
+        List<Dajim> nickDajims = dajimRepository.findAllByMember_Nickname("nick2")
                 .orElseThrow(()->new RuntimeException("해당 멤버에게 다짐이 없습니다."));
 
         assertThat(nickDajims.size()).isEqualTo(1);

--- a/src/test/java/challenge/nDaysChallenge/dajim/DajimServiceTest.java
+++ b/src/test/java/challenge/nDaysChallenge/dajim/DajimServiceTest.java
@@ -150,7 +150,7 @@ public class DajimServiceTest {
         DajimUpdateRequestDto dajimUpdateRequestDto = new DajimUpdateRequestDto(dajim.getNumber(), "수정한 내용", "PRIVATE");
 
         //when
-        when(dajimRepository.findByMemberIdAndRoomNumber(any(),any())).thenReturn(Optional.ofNullable(dajim));
+        when(dajimRepository.findByMember_IdAndRoom_Number(any(),any())).thenReturn(Optional.ofNullable(dajim));
         DajimResponseDto dajimResponseDto = dajimService.updateDajim(room.getNumber(), dajimUpdateRequestDto, member.getId());
 
         //then

--- a/src/test/java/challenge/nDaysChallenge/dajim/DajimTest.http
+++ b/src/test/java/challenge/nDaysChallenge/dajim/DajimTest.http
@@ -11,11 +11,11 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJpZDEyMzEyQGdtYWlsLmNvbSIsI
 ### 다짐 수정
 PATCH http://localhost:8080/challenge/314/dajim
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJpZDEyMzEyQGdtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2ODY5ODY4MjB9.H0NSdQHi1xsqwn0Qzm-PQXA67KsohjY4xd1j2_a7Vqs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJpZDEyMzEyQGdtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2ODY5ODgyMzZ9.EjfB3vDLuLv4Ml5jtGuDnNQ6xuSoxgl0gnxQ2Qc-34I
 
 {
   "dajimNumber": 90,
-  "content": "내용 수정",
+  "content": "내용 수정3",
   "open": "PUBLIC"
 }
 

--- a/src/test/java/challenge/nDaysChallenge/dajim/DajimTest.http
+++ b/src/test/java/challenge/nDaysChallenge/dajim/DajimTest.http
@@ -1,28 +1,28 @@
 ### 다짐 등록
-POST http://localhost:8080/challenge/6/dajim
+POST http://localhost:8080/challenge/314/dajim
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9..sFQYvr6nBtDJbHGwWbvWuRzYTu_PC6dnqO65BXJXMKM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJpZDEyMzEyQGdtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2ODY5ODY1NDF9.eGNPFtvyZemYC2IXJXbdKhfSMG-u1zhN0Vb36Wh_dEE
 
 {
-  "content": "",
+  "content": "다짐",
   "open": "PUBLIC"
 }
 
 ### 다짐 수정
-PATCH http://localhost:8080/challenge/3/dajim
+PATCH http://localhost:8080/challenge/314/dajim
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJpZDEyM0BnbWFpbC5jb20iLCJhdXRoIjoibnVsbCIsImV4cCI6MTY4MTAyNzkwNH0.E1fgMBeNF05yXzXNWPSIOyPgPKJnwRrM9oiZQUMT9bU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJpZDEyMzEyQGdtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2ODY5ODY4MjB9.H0NSdQHi1xsqwn0Qzm-PQXA67KsohjY4xd1j2_a7Vqs
 
 {
-  "dajimNumber": 3,
-  "content": "",
+  "dajimNumber": 90,
+  "content": "내용 수정",
   "open": "PUBLIC"
 }
 
 ### 챌린지룸 내 다짐 조회
-GET http://localhost:8080/challenge/1/dajim
+GET http://localhost:8080/challenge/314/dajim
 Content-Type: application/json
-Authorization: Bearer
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJpZDEyMzEyQGdtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2ODY5ODY4MjB9.H0NSdQHi1xsqwn0Qzm-PQXA67KsohjY4xd1j2_a7Vqs
 
 ### 피드 조회 (미로그인)
 GET {{review-api}}/feed?page=0

--- a/src/test/java/challenge/nDaysChallenge/emotion/EmotionRepositoryTest.java
+++ b/src/test/java/challenge/nDaysChallenge/emotion/EmotionRepositoryTest.java
@@ -91,10 +91,10 @@ public class EmotionRepositoryTest {
 
     @Test
     void 이모션_불러오기(){
-        Emotion savedEmotion1 = emotionRepository.findByDajimAndMember(savedDajim.getNumber(), savedMember1.getNumber())
+        Emotion savedEmotion1 = emotionRepository.findByDajim_NumberAndMember_Number(savedDajim.getNumber(), savedMember1.getNumber())
                 .orElseThrow(()->new RuntimeException("이모션을 찾을 수 없습니다."));
 
-        Emotion savedEmotion2 = emotionRepository.findByDajimAndMember(savedDajim.getNumber(), savedMember2.getNumber())
+        Emotion savedEmotion2 = emotionRepository.findByDajim_NumberAndMember_Number(savedDajim.getNumber(), savedMember2.getNumber())
                 .orElseThrow(()->new RuntimeException("이모션을 찾을 수 없습니다."));
 
         assertThat(savedEmotion1.getSticker().toString()).isEqualTo("CHEER");

--- a/src/test/java/challenge/nDaysChallenge/emotion/EmotionServiceTest.java
+++ b/src/test/java/challenge/nDaysChallenge/emotion/EmotionServiceTest.java
@@ -132,7 +132,7 @@ public class EmotionServiceTest {
 
         //when
         when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
-        when(emotionRepository.findByDajimAndMember(any(),any())).thenReturn(Optional.of(emotion));
+        when(emotionRepository.findByDajim_NumberAndMember_Number(any(),any())).thenReturn(Optional.of(emotion));
 
         EmotionRequestDto emotionRequestDto = new EmotionRequestDto(dajim.getNumber(), "SURPRISE");
         EmotionResponseDto emotionResponseDto = emotionService.updateEmotion(emotionRequestDto, member.getId());
@@ -161,7 +161,7 @@ public class EmotionServiceTest {
         //when
         when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
         when(dajimRepository.findByNumber(any())).thenReturn(Optional.of(dajim));
-        when(emotionRepository.findByDajimAndMember(any(),any())).thenReturn(Optional.of(emotion));
+        when(emotionRepository.findByDajim_NumberAndMember_Number(any(),any())).thenReturn(Optional.of(emotion));
 
         emotionService.deleteEmotion(emotionRequestDto, member.getId());
 

--- a/src/test/java/challenge/nDaysChallenge/member/MemberServiceTest.java
+++ b/src/test/java/challenge/nDaysChallenge/member/MemberServiceTest.java
@@ -165,7 +165,7 @@ public class MemberServiceTest {
                 .open(Open.PUBLIC).build();
 
         List<Dajim> dajims = Arrays.asList(dajim1, dajim2);
-        when(dajimRepository.findAllByMemberNickname(member.getNickname())).thenReturn(Optional.of(dajims));
+        when(dajimRepository.findAllByMember_Nickname(member.getNickname())).thenReturn(Optional.of(dajims));
 
         //when
         doNothing().when(memberRepository).delete(member);


### PR DESCRIPTION
- 다짐, 이모션 레포지토리 쿼리 메소드에 작성된 @Query 삭제
  - 쿼리 메소드만으로 동작하므로 중복된 코드 제거함
- 다짐 수정 서비스 메소드에서 중복된 유효성 검사 삭제
  - 다짐 작성자와 다짐이 소속된 챌린지룸을 검사하는 메소드를 따로 작성했었으나 findByMemberIdAndRoomNumber 메소드로 유효성 검사 진행되므로 메소드 제거함